### PR TITLE
draft idea for splitting internal bootstrap.Config

### DIFF
--- a/xds/bootstrap/bootstrap.go
+++ b/xds/bootstrap/bootstrap.go
@@ -29,6 +29,7 @@ import (
 	"encoding/json"
 
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 // registry is a map from credential type name to Credential builder.
@@ -43,6 +44,58 @@ type Credentials interface {
 	Build(config json.RawMessage) (credentials.Bundle, func(), error)
 	// Name returns the credential name associated with this credential.
 	Name() string
+}
+
+// ChannelCreds represents the credentials for the xDS server channel.
+type ChannelCreds struct {
+	Type   string
+	Config map[string]interface{}
+}
+
+// ServerConfig contains the configuration to connect to a server.
+type ServerConfig struct {
+	ServerURI    string
+	ChannelCreds []ChannelCreds
+	// Add other necessary fields.
+}
+
+// ServerConfigs represents a collection of server configurations.
+type ServerConfigs []*ServerConfig
+
+// Authority represents the configuration for an authority.
+type Authority struct {
+	ClientListenerResourceNameTemplate string `json:"client_listener_resource_name_template,omitempty"`
+	// XDSServers contains the list of server configurations for this authority.
+	XDSServers ServerConfigs `json:"xds_servers,omitempty"`
+	// Add other necessary fields.
+}
+
+// Node is the representation of the node field in the bootstrap
+// configuration.
+type Node struct {
+	ID       string           `json:"id,omitempty"`
+	Cluster  string           `json:"cluster,omitempty"`
+	Locality Locality         `json:"locality,omitempty"`
+	Metadata *structpb.Struct `json:"metadata,omitempty"`
+	// Add other necessary fields.
+}
+
+// Locality is the representation of the locality field within node.
+type Locality struct {
+	Region  string `json:"region,omitempty"`
+	Zone    string `json:"zone,omitempty"`
+	SubZone string `json:"sub_zone,omitempty"`
+	// Add other necessary fields.
+}
+
+// Config contains the generic bootstrap configuration for the xDS client.
+type Config struct {
+	XDSServers                                []ServerConfig
+	ServerListenerResourceNameTemplate        string
+	ClientDefaultListenerResourceNameTemplate string
+	Authorities                               map[string]*Authority
+	Node                                      *Node
+	// Add other necessary fields.
 }
 
 // RegisterCredentials registers Credentials used for connecting to the xds


### PR DESCRIPTION
- Move generic types from `internal/xds/bootstrap/bootstrap.go` to public `xds/bootstrap/bootsrap.go` including their implementation functions
-  keep Implementation-Specific fields in `internal/xds/bootstrap/bootstrap.go`
- Define the gRPC-specific Config and other structs by embedding the generic ones
- Update All Usages
