### PR TITLE
xds: generic xds client ADS stream transport channel

### DIFF
--- a/xds/internal/clients/backoff/backoff.go
+++ b/xds/internal/clients/backoff/backoff.go
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package backoff provides configuration options for backoff.
+//
+// More details can be found at:
+// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+//
+// All APIs in this package are experimental.
+package backoff
+
+import "time"
+
+// Config defines the configuration options for backoff.
+type Config struct {
+	// BaseDelay is the amount of time to backoff after the first failure.
+	BaseDelay time.Duration
+	// Multiplier is the factor with which to multiply backoffs after a
+	// failed retry. Should ideally be greater than 1.
+	Multiplier float64
+	// Jitter is the factor with which backoffs are randomized.
+	Jitter float64
+	// MaxDelay is the upper bound of backoff delay.
+	MaxDelay time.Duration
+}
+
+// DefaultConfig is a backoff configuration with the default values specified
+// at https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+//
+// This should be useful for callers who want to configure backoff with
+// non-default values only for a subset of the options.
+var DefaultConfig = Config{
+	BaseDelay:  1.0 * time.Second,
+	Multiplier: 1.6,
+	Jitter:     0.2,
+	MaxDelay:   120 * time.Second,
+}

--- a/xds/internal/clients/clientslog/clientslog.go
+++ b/xds/internal/clients/clientslog/clientslog.go
@@ -1,0 +1,186 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package clientslog defines logging for clients.
+//
+// In the default logger, severity level can be set by environment variable
+// CLIENTS_GO_LOG_SEVERITY_LEVEL, verbosity level can be set by
+// CLIENTS_GO_LOG_VERBOSITY_LEVEL.
+package clientslog
+
+import (
+	"os"
+
+	"google.golang.org/grpc/xds/internal/clients/clientslog/internal"
+)
+
+func init() {
+	SetLoggerV2(newLoggerV2())
+}
+
+// V reports whether verbosity level l is at least the requested verbose level.
+func V(l int) bool {
+	return internal.LoggerV2Impl.V(l)
+}
+
+// Info logs to the INFO log.
+func Info(args ...any) {
+	internal.LoggerV2Impl.Info(args...)
+}
+
+// Infof logs to the INFO log. Arguments are handled in the manner of fmt.Printf.
+func Infof(format string, args ...any) {
+	internal.LoggerV2Impl.Infof(format, args...)
+}
+
+// Infoln logs to the INFO log. Arguments are handled in the manner of fmt.Println.
+func Infoln(args ...any) {
+	internal.LoggerV2Impl.Infoln(args...)
+}
+
+// Warning logs to the WARNING log.
+func Warning(args ...any) {
+	internal.LoggerV2Impl.Warning(args...)
+}
+
+// Warningf logs to the WARNING log. Arguments are handled in the manner of fmt.Printf.
+func Warningf(format string, args ...any) {
+	internal.LoggerV2Impl.Warningf(format, args...)
+}
+
+// Warningln logs to the WARNING log. Arguments are handled in the manner of fmt.Println.
+func Warningln(args ...any) {
+	internal.LoggerV2Impl.Warningln(args...)
+}
+
+// Error logs to the ERROR log.
+func Error(args ...any) {
+	internal.LoggerV2Impl.Error(args...)
+}
+
+// Errorf logs to the ERROR log. Arguments are handled in the manner of fmt.Printf.
+func Errorf(format string, args ...any) {
+	internal.LoggerV2Impl.Errorf(format, args...)
+}
+
+// Errorln logs to the ERROR log. Arguments are handled in the manner of fmt.Println.
+func Errorln(args ...any) {
+	internal.LoggerV2Impl.Errorln(args...)
+}
+
+// Fatal logs to the FATAL log. Arguments are handled in the manner of fmt.Print.
+// It calls os.Exit() with exit code 1.
+func Fatal(args ...any) {
+	internal.LoggerV2Impl.Fatal(args...)
+	// Make sure fatal logs will exit.
+	os.Exit(1)
+}
+
+// Fatalf logs to the FATAL log. Arguments are handled in the manner of fmt.Printf.
+// It calls os.Exit() with exit code 1.
+func Fatalf(format string, args ...any) {
+	internal.LoggerV2Impl.Fatalf(format, args...)
+	// Make sure fatal logs will exit.
+	os.Exit(1)
+}
+
+// Fatalln logs to the FATAL log. Arguments are handled in the manner of fmt.Println.
+// It calls os.Exit() with exit code 1.
+func Fatalln(args ...any) {
+	internal.LoggerV2Impl.Fatalln(args...)
+	// Make sure fatal logs will exit.
+	os.Exit(1)
+}
+
+// Print prints to the logger. Arguments are handled in the manner of fmt.Print.
+//
+// Deprecated: use Info.
+func Print(args ...any) {
+	internal.LoggerV2Impl.Info(args...)
+}
+
+// Printf prints to the logger. Arguments are handled in the manner of fmt.Printf.
+//
+// Deprecated: use Infof.
+func Printf(format string, args ...any) {
+	internal.LoggerV2Impl.Infof(format, args...)
+}
+
+// Println prints to the logger. Arguments are handled in the manner of fmt.Println.
+//
+// Deprecated: use Infoln.
+func Println(args ...any) {
+	internal.LoggerV2Impl.Infoln(args...)
+}
+
+// InfoDepth logs to the INFO log at the specified depth.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func InfoDepth(depth int, args ...any) {
+	if internal.DepthLoggerV2Impl != nil {
+		internal.DepthLoggerV2Impl.InfoDepth(depth, args...)
+	} else {
+		internal.LoggerV2Impl.Infoln(args...)
+	}
+}
+
+// WarningDepth logs to the WARNING log at the specified depth.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func WarningDepth(depth int, args ...any) {
+	if internal.DepthLoggerV2Impl != nil {
+		internal.DepthLoggerV2Impl.WarningDepth(depth, args...)
+	} else {
+		internal.LoggerV2Impl.Warningln(args...)
+	}
+}
+
+// ErrorDepth logs to the ERROR log at the specified depth.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func ErrorDepth(depth int, args ...any) {
+	if internal.DepthLoggerV2Impl != nil {
+		internal.DepthLoggerV2Impl.ErrorDepth(depth, args...)
+	} else {
+		internal.LoggerV2Impl.Errorln(args...)
+	}
+}
+
+// FatalDepth logs to the FATAL log at the specified depth.
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+// later release.
+func FatalDepth(depth int, args ...any) {
+	if internal.DepthLoggerV2Impl != nil {
+		internal.DepthLoggerV2Impl.FatalDepth(depth, args...)
+	} else {
+		internal.LoggerV2Impl.Fatalln(args...)
+	}
+	os.Exit(1)
+}

--- a/xds/internal/clients/clientslog/component.go
+++ b/xds/internal/clients/clientslog/component.go
@@ -1,0 +1,115 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clientslog
+
+import (
+	"fmt"
+)
+
+// componentData records the settings for a component.
+type componentData struct {
+	name string
+}
+
+var cache = map[string]*componentData{}
+
+func (c *componentData) InfoDepth(depth int, args ...any) {
+	args = append([]any{"[" + string(c.name) + "]"}, args...)
+	InfoDepth(depth+1, args...)
+}
+
+func (c *componentData) WarningDepth(depth int, args ...any) {
+	args = append([]any{"[" + string(c.name) + "]"}, args...)
+	WarningDepth(depth+1, args...)
+}
+
+func (c *componentData) ErrorDepth(depth int, args ...any) {
+	args = append([]any{"[" + string(c.name) + "]"}, args...)
+	ErrorDepth(depth+1, args...)
+}
+
+func (c *componentData) FatalDepth(depth int, args ...any) {
+	args = append([]any{"[" + string(c.name) + "]"}, args...)
+	FatalDepth(depth+1, args...)
+}
+
+func (c *componentData) Info(args ...any) {
+	c.InfoDepth(1, args...)
+}
+
+func (c *componentData) Warning(args ...any) {
+	c.WarningDepth(1, args...)
+}
+
+func (c *componentData) Error(args ...any) {
+	c.ErrorDepth(1, args...)
+}
+
+func (c *componentData) Fatal(args ...any) {
+	c.FatalDepth(1, args...)
+}
+
+func (c *componentData) Infof(format string, args ...any) {
+	c.InfoDepth(1, fmt.Sprintf(format, args...))
+}
+
+func (c *componentData) Warningf(format string, args ...any) {
+	c.WarningDepth(1, fmt.Sprintf(format, args...))
+}
+
+func (c *componentData) Errorf(format string, args ...any) {
+	c.ErrorDepth(1, fmt.Sprintf(format, args...))
+}
+
+func (c *componentData) Fatalf(format string, args ...any) {
+	c.FatalDepth(1, fmt.Sprintf(format, args...))
+}
+
+func (c *componentData) Infoln(args ...any) {
+	c.InfoDepth(1, args...)
+}
+
+func (c *componentData) Warningln(args ...any) {
+	c.WarningDepth(1, args...)
+}
+
+func (c *componentData) Errorln(args ...any) {
+	c.ErrorDepth(1, args...)
+}
+
+func (c *componentData) Fatalln(args ...any) {
+	c.FatalDepth(1, args...)
+}
+
+func (c *componentData) V(l int) bool {
+	return V(l)
+}
+
+// Component creates a new component and returns it for logging. If a component
+// with the name already exists, nothing will be created and it will be
+// returned. SetLoggerV2 will panic if it is called with a logger created by
+// Component.
+func Component(componentName string) DepthLoggerV2 {
+	if cData, ok := cache[componentName]; ok {
+		return cData
+	}
+	c := &componentData{componentName}
+	cache[componentName] = c
+	return c
+}

--- a/xds/internal/clients/clientslog/glogger/glogger.go
+++ b/xds/internal/clients/clientslog/glogger/glogger.go
@@ -1,0 +1,104 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package glogger defines glog-based logging for clients.
+// Importing this package will install glog as the logger used by clientslog.
+package glogger
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc/xds/internal/clients/clientslog"
+)
+
+const d = 2
+
+func init() {
+	clientslog.SetLoggerV2(&glogger{})
+}
+
+type glogger struct{}
+
+func (g *glogger) Info(args ...any) {
+	glog.InfoDepth(d, args...)
+}
+
+func (g *glogger) Infoln(args ...any) {
+	glog.InfoDepth(d, fmt.Sprintln(args...))
+}
+
+func (g *glogger) Infof(format string, args ...any) {
+	glog.InfoDepth(d, fmt.Sprintf(format, args...))
+}
+
+func (g *glogger) InfoDepth(depth int, args ...any) {
+	glog.InfoDepth(depth+d, args...)
+}
+
+func (g *glogger) Warning(args ...any) {
+	glog.WarningDepth(d, args...)
+}
+
+func (g *glogger) Warningln(args ...any) {
+	glog.WarningDepth(d, fmt.Sprintln(args...))
+}
+
+func (g *glogger) Warningf(format string, args ...any) {
+	glog.WarningDepth(d, fmt.Sprintf(format, args...))
+}
+
+func (g *glogger) WarningDepth(depth int, args ...any) {
+	glog.WarningDepth(depth+d, args...)
+}
+
+func (g *glogger) Error(args ...any) {
+	glog.ErrorDepth(d, args...)
+}
+
+func (g *glogger) Errorln(args ...any) {
+	glog.ErrorDepth(d, fmt.Sprintln(args...))
+}
+
+func (g *glogger) Errorf(format string, args ...any) {
+	glog.ErrorDepth(d, fmt.Sprintf(format, args...))
+}
+
+func (g *glogger) ErrorDepth(depth int, args ...any) {
+	glog.ErrorDepth(depth+d, args...)
+}
+
+func (g *glogger) Fatal(args ...any) {
+	glog.FatalDepth(d, args...)
+}
+
+func (g *glogger) Fatalln(args ...any) {
+	glog.FatalDepth(d, fmt.Sprintln(args...))
+}
+
+func (g *glogger) Fatalf(format string, args ...any) {
+	glog.FatalDepth(d, fmt.Sprintf(format, args...))
+}
+
+func (g *glogger) FatalDepth(depth int, args ...any) {
+	glog.FatalDepth(depth+d, args...)
+}
+
+func (g *glogger) V(l int) bool {
+	return bool(glog.V(glog.Level(l)))
+}

--- a/xds/internal/clients/clientslog/internal/clientslog.go
+++ b/xds/internal/clients/clientslog/internal/clientslog.go
@@ -1,0 +1,26 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package internal contains functionality internal to the clientslog package.
+package internal
+
+// LoggerV2Impl is the logger used for the non-depth log functions.
+var LoggerV2Impl LoggerV2
+
+// DepthLoggerV2Impl is the logger used for the depth log functions.
+var DepthLoggerV2Impl DepthLoggerV2

--- a/xds/internal/clients/clientslog/internal/loggerv2.go
+++ b/xds/internal/clients/clientslog/internal/loggerv2.go
@@ -1,0 +1,267 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+// LoggerV2 does underlying logging work for clientslog.
+type LoggerV2 interface {
+	// Info logs to INFO log. Arguments are handled in the manner of fmt.Print.
+	Info(args ...any)
+	// Infoln logs to INFO log. Arguments are handled in the manner of fmt.Println.
+	Infoln(args ...any)
+	// Infof logs to INFO log. Arguments are handled in the manner of fmt.Printf.
+	Infof(format string, args ...any)
+	// Warning logs to WARNING log. Arguments are handled in the manner of fmt.Print.
+	Warning(args ...any)
+	// Warningln logs to WARNING log. Arguments are handled in the manner of fmt.Println.
+	Warningln(args ...any)
+	// Warningf logs to WARNING log. Arguments are handled in the manner of fmt.Printf.
+	Warningf(format string, args ...any)
+	// Error logs to ERROR log. Arguments are handled in the manner of fmt.Print.
+	Error(args ...any)
+	// Errorln logs to ERROR log. Arguments are handled in the manner of fmt.Println.
+	Errorln(args ...any)
+	// Errorf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
+	Errorf(format string, args ...any)
+	// Fatal logs to ERROR log. Arguments are handled in the manner of fmt.Print.
+	// clients ensures that all Fatal logs will exit with os.Exit(1).
+	// Implementations may also call os.Exit() with a non-zero exit code.
+	Fatal(args ...any)
+	// Fatalln logs to ERROR log. Arguments are handled in the manner of fmt.Println.
+	// clients ensures that all Fatal logs will exit with os.Exit(1).
+	// Implementations may also call os.Exit() with a non-zero exit code.
+	Fatalln(args ...any)
+	// Fatalf logs to ERROR log. Arguments are handled in the manner of fmt.Printf.
+	// clients ensures that all Fatal logs will exit with os.Exit(1).
+	// Implementations may also call os.Exit() with a non-zero exit code.
+	Fatalf(format string, args ...any)
+	// V reports whether verbosity level l is at least the requested verbose level.
+	V(l int) bool
+}
+
+// DepthLoggerV2 logs at a specified call frame. If a LoggerV2 also implements
+// DepthLoggerV2, the below functions will be called with the appropriate stack
+// depth set for trivial functions the logger may ignore.
+//
+// # Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type DepthLoggerV2 interface {
+	LoggerV2
+	// InfoDepth logs to INFO log at the specified depth. Arguments are handled in the manner of fmt.Println.
+	InfoDepth(depth int, args ...any)
+	// WarningDepth logs to WARNING log at the specified depth. Arguments are handled in the manner of fmt.Println.
+	WarningDepth(depth int, args ...any)
+	// ErrorDepth logs to ERROR log at the specified depth. Arguments are handled in the manner of fmt.Println.
+	ErrorDepth(depth int, args ...any)
+	// FatalDepth logs to FATAL log at the specified depth. Arguments are handled in the manner of fmt.Println.
+	FatalDepth(depth int, args ...any)
+}
+
+const (
+	// infoLog indicates Info severity.
+	infoLog int = iota
+	// warningLog indicates Warning severity.
+	warningLog
+	// errorLog indicates Error severity.
+	errorLog
+	// fatalLog indicates Fatal severity.
+	fatalLog
+)
+
+// severityName contains the string representation of each severity.
+var severityName = []string{
+	infoLog:    "INFO",
+	warningLog: "WARNING",
+	errorLog:   "ERROR",
+	fatalLog:   "FATAL",
+}
+
+// sprintf is fmt.Sprintf.
+// These vars exist to make it possible to test that expensive format calls aren't made unnecessarily.
+var sprintf = fmt.Sprintf
+
+// sprint is fmt.Sprint.
+// These vars exist to make it possible to test that expensive format calls aren't made unnecessarily.
+var sprint = fmt.Sprint
+
+// sprintln is fmt.Sprintln.
+// These vars exist to make it possible to test that expensive format calls aren't made unnecessarily.
+var sprintln = fmt.Sprintln
+
+// exit is os.Exit.
+// This var exists to make it possible to test functions calling os.Exit.
+var exit = os.Exit
+
+// loggerT is the default logger used by clientslog.
+type loggerT struct {
+	m          []*log.Logger
+	v          int
+	jsonFormat bool
+}
+
+func (g *loggerT) output(severity int, s string) {
+	sevStr := severityName[severity]
+	if !g.jsonFormat {
+		g.m[severity].Output(2, sevStr+": "+s)
+		return
+	}
+	// TODO: we can also include the logging component, but that needs more
+	// (API) changes.
+	b, _ := json.Marshal(map[string]string{
+		"severity": sevStr,
+		"message":  s,
+	})
+	g.m[severity].Output(2, string(b))
+}
+
+func (g *loggerT) printf(severity int, format string, args ...any) {
+	// Note the discard check is duplicated in each print func, rather than in
+	// output, to avoid the expensive Sprint calls.
+	// De-duplicating this by moving to output would be a significant performance regression!
+	if lg := g.m[severity]; lg.Writer() == io.Discard {
+		return
+	}
+	g.output(severity, sprintf(format, args...))
+}
+
+func (g *loggerT) print(severity int, v ...any) {
+	if lg := g.m[severity]; lg.Writer() == io.Discard {
+		return
+	}
+	g.output(severity, sprint(v...))
+}
+
+func (g *loggerT) println(severity int, v ...any) {
+	if lg := g.m[severity]; lg.Writer() == io.Discard {
+		return
+	}
+	g.output(severity, sprintln(v...))
+}
+
+func (g *loggerT) Info(args ...any) {
+	g.print(infoLog, args...)
+}
+
+func (g *loggerT) Infoln(args ...any) {
+	g.println(infoLog, args...)
+}
+
+func (g *loggerT) Infof(format string, args ...any) {
+	g.printf(infoLog, format, args...)
+}
+
+func (g *loggerT) Warning(args ...any) {
+	g.print(warningLog, args...)
+}
+
+func (g *loggerT) Warningln(args ...any) {
+	g.println(warningLog, args...)
+}
+
+func (g *loggerT) Warningf(format string, args ...any) {
+	g.printf(warningLog, format, args...)
+}
+
+func (g *loggerT) Error(args ...any) {
+	g.print(errorLog, args...)
+}
+
+func (g *loggerT) Errorln(args ...any) {
+	g.println(errorLog, args...)
+}
+
+func (g *loggerT) Errorf(format string, args ...any) {
+	g.printf(errorLog, format, args...)
+}
+
+func (g *loggerT) Fatal(args ...any) {
+	g.print(fatalLog, args...)
+	exit(1)
+}
+
+func (g *loggerT) Fatalln(args ...any) {
+	g.println(fatalLog, args...)
+	exit(1)
+}
+
+func (g *loggerT) Fatalf(format string, args ...any) {
+	g.printf(fatalLog, format, args...)
+	exit(1)
+}
+
+func (g *loggerT) V(l int) bool {
+	return l <= g.v
+}
+
+// LoggerV2Config configures the LoggerV2 implementation.
+type LoggerV2Config struct {
+	// Verbosity sets the verbosity level of the logger.
+	Verbosity int
+	// FormatJSON controls whether the logger should output logs in JSON format.
+	FormatJSON bool
+}
+
+// combineLoggers returns a combined logger for both higher & lower severity logs,
+// or only one if the other is io.Discard.
+//
+// This uses io.Discard instead of io.MultiWriter when all loggers
+// are set to io.Discard. Both this package and the standard log package have
+// significant optimizations for io.Discard, which io.MultiWriter lacks (as of
+// this writing).
+func combineLoggers(lower, higher io.Writer) io.Writer {
+	if lower == io.Discard {
+		return higher
+	}
+	if higher == io.Discard {
+		return lower
+	}
+	return io.MultiWriter(lower, higher)
+}
+
+// NewLoggerV2 creates a new LoggerV2 instance with the provided configuration.
+// The infoW, warningW, and errorW writers are used to write log messages of
+// different severity levels.
+func NewLoggerV2(infoW, warningW, errorW io.Writer, c LoggerV2Config) LoggerV2 {
+	flag := log.LstdFlags
+	if c.FormatJSON {
+		flag = 0
+	}
+
+	warningW = combineLoggers(infoW, warningW)
+	errorW = combineLoggers(errorW, warningW)
+
+	fatalW := errorW
+
+	m := []*log.Logger{
+		log.New(infoW, "", flag),
+		log.New(warningW, "", flag),
+		log.New(errorW, "", flag),
+		log.New(fatalW, "", flag),
+	}
+	return &loggerT{m: m, v: c.Verbosity, jsonFormat: c.FormatJSON}
+}

--- a/xds/internal/clients/clientslog/internal/loggerv2_test.go
+++ b/xds/internal/clients/clientslog/internal/loggerv2_test.go
@@ -1,0 +1,350 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package internal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// logFuncStr is a string used via testCheckLogContainsFuncStr to test the
+// logger output.
+const logFuncStr = "called-func"
+
+func makeSprintfErr(t *testing.T) func(format string, a ...any) string {
+	return func(string, ...any) string {
+		t.Errorf("got: sprintf called on io.Discard logger, want: expensive sprintf to not be called for io.Discard")
+		return ""
+	}
+}
+
+func makeSprintErr(t *testing.T) func(a ...any) string {
+	return func(...any) string {
+		t.Errorf("got: sprint called on io.Discard logger, want: expensive sprint to not be called for io.Discard")
+		return ""
+	}
+}
+
+// checkLogContainsFuncStr checks that the logger buffer logBuf contains
+// logFuncStr.
+func checkLogContainsFuncStr(t *testing.T, logBuf []byte) {
+	if !bytes.Contains(logBuf, []byte(logFuncStr)) {
+		t.Errorf("got '%v', want logger func to be called and print '%v'", string(logBuf), logFuncStr)
+	}
+}
+
+// checkBufferWasWrittenAsExpected checks that the log buffer buf was written as expected,
+// per the discard, logTYpe, msg, and isJSON arguments.
+func checkBufferWasWrittenAsExpected(t *testing.T, buf *bytes.Buffer, discard bool, logType string, msg string, isJSON bool) {
+	bts, err := buf.ReadBytes('\n')
+	if discard {
+		if err == nil {
+			t.Fatalf("got '%v', want discard %v to not write", string(bts), logType)
+		} else if err != io.EOF {
+			t.Fatalf("got '%v', want discard %v buffer to be EOF", err, logType)
+		}
+	} else {
+		if err != nil {
+			t.Fatalf("got '%v', want non-discard %v to not error", err, logType)
+		} else if !bytes.Contains(bts, []byte(msg)) {
+			t.Fatalf("got '%v', want non-discard %v buffer contain message '%v'", string(bts), logType, msg)
+		}
+		if isJSON {
+			obj := map[string]string{}
+			if err := json.Unmarshal(bts, &obj); err != nil {
+				t.Fatalf("got '%v', want non-discard json %v to unmarshal", err, logType)
+			} else if _, ok := obj["severity"]; !ok {
+				t.Fatalf("got '%v', want non-discard json %v to have severity field", "missing severity", logType)
+
+			} else if jsonMsg, ok := obj["message"]; !ok {
+				t.Fatalf("got '%v', want non-discard json %v to have message field", "missing message", logType)
+
+			} else if !strings.Contains(jsonMsg, msg) {
+				t.Fatalf("got '%v', want non-discard json %v buffer contain message '%v'", string(bts), logType, msg)
+			}
+		}
+	}
+}
+
+// check if b is in the format of:
+//
+//	2017/04/07 14:55:42 WARNING: WARNING
+func checkLogForSeverity(s int, b []byte) error {
+	expected := regexp.MustCompile(fmt.Sprintf(`^[0-9]{4}/[0-9]{2}/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} %s: %s\n$`, severityName[s], severityName[s]))
+	if m := expected.Match(b); !m {
+		return fmt.Errorf("got: %v, want string in format of: %v", string(b), severityName[s]+": 2016/10/05 17:09:26 "+severityName[s])
+	}
+	return nil
+}
+
+func TestLoggerV2Severity(t *testing.T) {
+	buffers := []*bytes.Buffer{new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)}
+	l := NewLoggerV2(buffers[infoLog], buffers[warningLog], buffers[errorLog], LoggerV2Config{})
+
+	l.Info(severityName[infoLog])
+	l.Warning(severityName[warningLog])
+	l.Error(severityName[errorLog])
+
+	for i := 0; i < fatalLog; i++ {
+		buf := buffers[i]
+		// The content of info buffer should be something like:
+		//  INFO: 2017/04/07 14:55:42 INFO
+		//  WARNING: 2017/04/07 14:55:42 WARNING
+		//  ERROR: 2017/04/07 14:55:42 ERROR
+		for j := i; j < fatalLog; j++ {
+			b, err := buf.ReadBytes('\n')
+			if err != nil {
+				t.Fatalf("level %d: %v", j, err)
+			}
+			if err := checkLogForSeverity(j, b); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+// TestLoggerV2PrintFuncDiscardOnlyInfo ensures that logs at the INFO level are
+// discarded when set to io.Discard, while logs at other levels (WARN, ERROR)
+// are still printed. It does this by using a custom error function that raises
+// an error if the logger attempts to print at the INFO level, ensuring early
+// return when io.Discard is used.
+func TestLoggerV2PrintFuncDiscardOnlyInfo(t *testing.T) {
+	buffers := []*bytes.Buffer{nil, new(bytes.Buffer), new(bytes.Buffer)}
+	logger := NewLoggerV2(io.Discard, buffers[warningLog], buffers[errorLog], LoggerV2Config{})
+	loggerTp := logger.(*loggerT)
+
+	// test that output doesn't call expensive printf funcs on an io.Discard logger
+	sprintf = makeSprintfErr(t)
+	sprint = makeSprintErr(t)
+	sprintln = makeSprintErr(t)
+
+	loggerTp.output(infoLog, "something")
+
+	sprintf = fmt.Sprintf
+	sprint = fmt.Sprint
+	sprintln = fmt.Sprintln
+
+	loggerTp.output(errorLog, logFuncStr)
+	warnB, err := buffers[warningLog].ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("level %v: %v", warningLog, err)
+	}
+	checkLogContainsFuncStr(t, warnB)
+
+	errB, err := buffers[errorLog].ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("level %v: %v", errorLog, err)
+	}
+	checkLogContainsFuncStr(t, errB)
+}
+
+func TestLoggerV2PrintFuncNoDiscard(t *testing.T) {
+	buffers := []*bytes.Buffer{new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)}
+	logger := NewLoggerV2(buffers[infoLog], buffers[warningLog], buffers[errorLog], LoggerV2Config{})
+	loggerTp := logger.(*loggerT)
+
+	loggerTp.output(errorLog, logFuncStr)
+
+	infoB, err := buffers[infoLog].ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("level %v: %v", infoLog, err)
+	}
+	checkLogContainsFuncStr(t, infoB)
+
+	warnB, err := buffers[warningLog].ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("level %v: %v", warningLog, err)
+	}
+	checkLogContainsFuncStr(t, warnB)
+
+	errB, err := buffers[errorLog].ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("level %v: %v", errorLog, err)
+	}
+	checkLogContainsFuncStr(t, errB)
+}
+
+// TestLoggerV2PrintFuncAllDiscard tests that discard loggers don't log.
+func TestLoggerV2PrintFuncAllDiscard(t *testing.T) {
+	logger := NewLoggerV2(io.Discard, io.Discard, io.Discard, LoggerV2Config{})
+	loggerTp := logger.(*loggerT)
+
+	sprintf = makeSprintfErr(t)
+	sprint = makeSprintErr(t)
+	sprintln = makeSprintErr(t)
+
+	// test that printFunc doesn't call the log func on discard loggers
+	// makeLogFuncErr will fail the test if it's called
+	loggerTp.output(infoLog, logFuncStr)
+	loggerTp.output(warningLog, logFuncStr)
+	loggerTp.output(errorLog, logFuncStr)
+
+	sprintf = fmt.Sprintf
+	sprint = fmt.Sprint
+	sprintln = fmt.Sprintln
+}
+
+func TestLoggerV2PrintFuncAllCombinations(t *testing.T) {
+	const (
+		print int = iota
+		printf
+		println
+	)
+
+	type testDiscard struct {
+		discardInf  bool
+		discardWarn bool
+		discardErr  bool
+
+		printType  int
+		formatJSON bool
+	}
+
+	discardName := func(td testDiscard) string {
+		strs := []string{}
+		if td.discardInf {
+			strs = append(strs, "discardInfo")
+		}
+		if td.discardWarn {
+			strs = append(strs, "discardWarn")
+		}
+		if td.discardErr {
+			strs = append(strs, "discardErr")
+		}
+		if len(strs) == 0 {
+			strs = append(strs, "noDiscard")
+		}
+		return strings.Join(strs, " ")
+	}
+	var printName = []string{
+		print:   "print",
+		printf:  "printf",
+		println: "println",
+	}
+	var jsonName = map[bool]string{
+		true:  "json",
+		false: "noJson",
+	}
+
+	discardTests := []testDiscard{}
+	for _, di := range []bool{true, false} {
+		for _, dw := range []bool{true, false} {
+			for _, de := range []bool{true, false} {
+				for _, pt := range []int{print, printf, println} {
+					for _, fj := range []bool{true, false} {
+						discardTests = append(discardTests, testDiscard{discardInf: di, discardWarn: dw, discardErr: de, printType: pt, formatJSON: fj})
+					}
+				}
+			}
+		}
+	}
+
+	for _, discardTest := range discardTests {
+		testName := fmt.Sprintf("%v %v %v", jsonName[discardTest.formatJSON], printName[discardTest.printType], discardName(discardTest))
+		t.Run(testName, func(t *testing.T) {
+			cfg := LoggerV2Config{FormatJSON: discardTest.formatJSON}
+
+			buffers := []*bytes.Buffer{new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)}
+			writers := []io.Writer{buffers[infoLog], buffers[warningLog], buffers[errorLog]}
+			if discardTest.discardInf {
+				writers[infoLog] = io.Discard
+			}
+			if discardTest.discardWarn {
+				writers[warningLog] = io.Discard
+			}
+			if discardTest.discardErr {
+				writers[errorLog] = io.Discard
+			}
+			logger := NewLoggerV2(writers[infoLog], writers[warningLog], writers[errorLog], cfg)
+
+			msgInf := "someinfo"
+			msgWarn := "somewarn"
+			msgErr := "someerr"
+			if discardTest.printType == print {
+				logger.Info(msgInf)
+				logger.Warning(msgWarn)
+				logger.Error(msgErr)
+			} else if discardTest.printType == printf {
+				logger.Infof("%v", msgInf)
+				logger.Warningf("%v", msgWarn)
+				logger.Errorf("%v", msgErr)
+			} else if discardTest.printType == println {
+				logger.Infoln(msgInf)
+				logger.Warningln(msgWarn)
+				logger.Errorln(msgErr)
+			}
+
+			// verify the test Discard, log type, message, and json arguments were logged as-expected
+
+			checkBufferWasWrittenAsExpected(t, buffers[infoLog], discardTest.discardInf, "info", msgInf, cfg.FormatJSON)
+			checkBufferWasWrittenAsExpected(t, buffers[warningLog], discardTest.discardWarn, "warning", msgWarn, cfg.FormatJSON)
+			checkBufferWasWrittenAsExpected(t, buffers[errorLog], discardTest.discardErr, "error", msgErr, cfg.FormatJSON)
+		})
+	}
+}
+
+func TestLoggerV2Fatal(t *testing.T) {
+	const (
+		print   = "print"
+		println = "println"
+		printf  = "printf"
+	)
+	printFuncs := []string{print, println, printf}
+
+	exitCalls := []int{}
+
+	if reflect.ValueOf(exit).Pointer() != reflect.ValueOf(os.Exit).Pointer() {
+		t.Error("got: exit isn't os.Exit, want exit var to be os.Exit")
+	}
+
+	exit = func(code int) {
+		exitCalls = append(exitCalls, code)
+	}
+	defer func() {
+		exit = os.Exit
+	}()
+
+	for _, printFunc := range printFuncs {
+		buffers := []*bytes.Buffer{new(bytes.Buffer), new(bytes.Buffer), new(bytes.Buffer)}
+		logger := NewLoggerV2(buffers[infoLog], buffers[warningLog], buffers[errorLog], LoggerV2Config{})
+		switch printFunc {
+		case print:
+			logger.Fatal("fatal")
+		case println:
+			logger.Fatalln("fatalln")
+		case printf:
+			logger.Fatalf("fatalf %d", 42)
+		default:
+			t.Errorf("unknown print type '%v'", printFunc)
+		}
+
+		checkBufferWasWrittenAsExpected(t, buffers[errorLog], false, "fatal", "fatal", false)
+		if len(exitCalls) == 0 {
+			t.Error("got: no exit call, want fatal log to call exit")
+		}
+		exitCalls = []int{}
+	}
+}

--- a/xds/internal/clients/clientslog/loggerv2.go
+++ b/xds/internal/clients/clientslog/loggerv2.go
@@ -1,0 +1,97 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clientslog
+
+import (
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc/xds/internal/clients/clientslog/internal"
+)
+
+// LoggerV2 does underlying logging work for clientslog.
+type LoggerV2 internal.LoggerV2
+
+// SetLoggerV2 sets logger that is used in clients to a V2 logger.
+// Not mutex-protected, should be called before any gRPC functions.
+func SetLoggerV2(l LoggerV2) {
+	if _, ok := l.(*componentData); ok {
+		panic("cannot use component logger as clientslog logger")
+	}
+	internal.LoggerV2Impl = l
+	internal.DepthLoggerV2Impl, _ = l.(internal.DepthLoggerV2)
+}
+
+// NewLoggerV2 creates a loggerV2 with the provided writers.
+// Fatal logs will be written to errorW, warningW, infoW, followed by exit(1).
+// Error logs will be written to errorW, warningW and infoW.
+// Warning logs will be written to warningW and infoW.
+// Info logs will be written to infoW.
+func NewLoggerV2(infoW, warningW, errorW io.Writer) LoggerV2 {
+	return internal.NewLoggerV2(infoW, warningW, errorW, internal.LoggerV2Config{})
+}
+
+// NewLoggerV2WithVerbosity creates a loggerV2 with the provided writers and
+// verbosity level.
+func NewLoggerV2WithVerbosity(infoW, warningW, errorW io.Writer, v int) LoggerV2 {
+	return internal.NewLoggerV2(infoW, warningW, errorW, internal.LoggerV2Config{Verbosity: v})
+}
+
+// newLoggerV2 creates a loggerV2 to be used as default logger.
+// All logs are written to stderr.
+func newLoggerV2() LoggerV2 {
+	errorW := io.Discard
+	warningW := io.Discard
+	infoW := io.Discard
+
+	logLevel := os.Getenv("CLIENTS_GO_LOG_SEVERITY_LEVEL")
+	switch logLevel {
+	case "", "ERROR", "error": // If env is unset, set level to ERROR.
+		errorW = os.Stderr
+	case "WARNING", "warning":
+		warningW = os.Stderr
+	case "INFO", "info":
+		infoW = os.Stderr
+	}
+
+	var v int
+	vLevel := os.Getenv("CLIENTS_GO_LOG_VERBOSITY_LEVEL")
+	if vl, err := strconv.Atoi(vLevel); err == nil {
+		v = vl
+	}
+
+	jsonFormat := strings.EqualFold(os.Getenv("CLIENTS_GO_LOG_FORMATTER"), "json")
+
+	return internal.NewLoggerV2(infoW, warningW, errorW, internal.LoggerV2Config{
+		Verbosity:  v,
+		FormatJSON: jsonFormat,
+	})
+}
+
+// DepthLoggerV2 logs at a specified call frame. If a LoggerV2 also implements
+// DepthLoggerV2, the below functions will be called with the appropriate stack
+// depth set for trivial functions the logger may ignore.
+//
+// # Experimental
+//
+// Notice: This type is EXPERIMENTAL and may be changed or removed in a
+// later release.
+type DepthLoggerV2 internal.DepthLoggerV2

--- a/xds/internal/clients/config.go
+++ b/xds/internal/clients/config.go
@@ -16,11 +16,10 @@
  *
  */
 
-// Package clients provides implementations of the xDS and LRS clients,
-// enabling applications to communicate with xDS management servers and report
-// load.
+// Package clients provides implementations of the clients to interact with
+// xDS and LRS servers.
 //
-// xDS Client
+// # xDS Client
 //
 // The xDS client allows applications to:
 //   - Create client instances with in-memory configurations.
@@ -41,100 +40,33 @@
 //
 // NOTICE: This package is EXPERIMENTAL and may be changed or removed
 // in a later release.
-//
-// See [README](https://github.com/grpc/grpc-go/tree/master/xds/clients/README.md).
 package clients
 
-import (
-	"fmt"
-	"slices"
-	"strings"
-
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/structpb"
-
-	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-)
-
-// ServerConfig holds settings for connecting to an xDS management server.
-type ServerConfig struct {
-	// ServerURI is the target URI of the xDS management server.
+// ServerIdentifier holds identifying information for connecting to an xDS
+// management or LRS server.
+type ServerIdentifier struct {
+	// ServerURI is the target URI of the server.
 	ServerURI string
 
-	// IgnoreResourceDeletion is a server feature which if set to true,
-	// indicates that resource deletion errors can be ignored and cached
-	// resource data can be used.
-	//
-	// This will be removed in the future once we implement gRFC A88
-	// and two new fields FailOnDataErrors and
-	// ResourceTimerIsTransientError will be introduced.
-	IgnoreResourceDeletion bool
-
 	// Extensions can be populated with arbitrary data to be passed to the
-	// [TransportBuilder] and/or xDS Client's ResourceType implementations.
+	// TransportBuilder and/or xDS Client's ResourceType implementations.
 	// This field can be used to provide additional configuration or context
 	// specific to the user's needs.
 	//
 	// The xDS and LRS clients do not interpret the contents of this field.
-	// It is the responsibility of the user's custom [TransportBuilder] and/or
+	// It is the responsibility of the user's custom TransportBuilder and/or
 	// ResourceType implementations to handle and interpret these extensions.
 	//
-	// For example, a custom [TransportBuilder] might use this field to
+	// For example, a custom TransportBuilder might use this field to
 	// configure a specific security credentials.
 	//
 	// Note: For custom types used in Extensions, ensure an Equal(any) bool
-	// method is implemented for equality checks on ServerConfig.
+	// method is implemented for equality checks on ServerIdentifier.
 	Extensions any
 }
 
-// equal returns true if sc and other are considered equal.
-func (sc *ServerConfig) equal(other *ServerConfig) bool {
-	switch {
-	case sc == nil && other == nil:
-		return true
-	case (sc != nil) != (other != nil):
-		return false
-	case sc.ServerURI != other.ServerURI:
-		return false
-	case sc.IgnoreResourceDeletion != other.IgnoreResourceDeletion:
-		return false
-	}
-	if sc.Extensions == nil && other.Extensions == nil {
-		return true
-	}
-	if ex, ok := sc.Extensions.(interface{ Equal(any) bool }); ok && ex.Equal(other.Extensions) {
-		return true
-	}
-	return false
-}
-
-// String returns a string representation of the [ServerConfig].
-//
-// WARNING: This method is primarily intended for logging and testing
-// purposes. The output returned by this method is not guaranteed to be stable
-// and may change at any time. Do not rely on it for production use.
-func (sc *ServerConfig) String() string {
-	return strings.Join([]string{sc.ServerURI, fmt.Sprintf("%v", sc.IgnoreResourceDeletion)}, "-")
-}
-
-// Authority contains configuration for an xDS control plane authority.
-type Authority struct {
-	// XDSServers contains the list of server configurations for this authority.
-	XDSServers []ServerConfig
-
-	// Extensions can be populated with arbitrary data to be passed to the xDS
-	// Client's user specific implementations. This field can be used to
-	// provide additional configuration or context specific to the user's
-	// needs.
-	//
-	// The xDS and LRS clients do not interpret the contents of this field. It
-	// is the responsibility of the user's implementations to handle and
-	// interpret these extensions.
-	Extensions any
-}
-
-// Node represents the identity of the xDS client, allowing
-// management servers to identify the source of xDS requests.
+// Node represents the identity of the xDS client, allowing xDS and LRS servers
+// to identify the source of xDS requests.
 type Node struct {
 	// ID is a string identifier of the application.
 	ID string
@@ -150,40 +82,6 @@ type Node struct {
 	UserAgentName string
 	// UserAgentVersion is the user agent version of application.
 	UserAgentVersion string
-	// ClientFeatures is a list of xDS features supported by this client.
-	// These features are set within the xDS client, but may be overridden only
-	// for testing purposes.
-	clientFeatures []string
-}
-
-// toProto converts an instance of [Node] to its protobuf representation.
-func (n Node) toProto() *v3corepb.Node {
-	return &v3corepb.Node{
-		Id:      n.ID,
-		Cluster: n.Cluster,
-		Locality: func() *v3corepb.Locality {
-			if n.Locality.isEmpty() {
-				return nil
-			}
-			return &v3corepb.Locality{
-				Region:  n.Locality.Region,
-				Zone:    n.Locality.Zone,
-				SubZone: n.Locality.SubZone,
-			}
-		}(),
-		Metadata: func() *structpb.Struct {
-			if n.Metadata == nil {
-				return nil
-			}
-			if md, ok := n.Metadata.(*structpb.Struct); ok {
-				return proto.Clone(md).(*structpb.Struct)
-			}
-			return nil
-		}(),
-		UserAgentName:        n.UserAgentName,
-		UserAgentVersionType: &v3corepb.Node_UserAgentVersion{UserAgentVersion: n.UserAgentVersion},
-		ClientFeatures:       slices.Clone(n.clientFeatures),
-	}
 }
 
 // Locality represents the location of the xDS client application.
@@ -194,14 +92,4 @@ type Locality struct {
 	Zone string
 	// SubZone is the further subdivision within a zone.
 	SubZone string
-}
-
-// isEmpty reports whether l is considered empty.
-func (l Locality) isEmpty() bool {
-	return l.equal(Locality{})
-}
-
-// equal returns true if l and other are considered equal.
-func (l Locality) equal(other Locality) bool {
-	return l.Region == other.Region && l.Zone == other.Zone && l.SubZone == other.SubZone
 }

--- a/xds/internal/clients/grpctransport/grpc_transport.go
+++ b/xds/internal/clients/grpctransport/grpc_transport.go
@@ -28,41 +28,42 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+
 	"google.golang.org/grpc/xds/internal/clients"
 )
 
-// ServerConfigExtension holds settings for connecting to a gRPC server,
+// ServerIdentifierExtension holds settings for connecting to a gRPC server,
 // such as an xDS management or an LRS server.
-type ServerConfigExtension struct {
+type ServerIdentifierExtension struct {
 	// Credentials will be used for all gRPC transports. If it is unset,
 	// transport creation will fail.
 	Credentials credentials.Bundle
 }
 
-// Builder creates gRPC-based Transports. It must be paired with ServerConfigs
-// that contain an Extension field of type ServerConfigExtension.
+// Builder creates gRPC-based Transports. It must be paired with ServerIdentifiers
+// that contain an Extension field of type ServerIdentifierExtension.
 type Builder struct{}
 
 // Build returns a gRPC-based clients.Transport.
 //
-// The Extension field of the ServerConfig must be a ServerConfigExtension.
-func (b *Builder) Build(sc clients.ServerConfig) (clients.Transport, error) {
-	if sc.ServerURI == "" {
-		return nil, fmt.Errorf("grpctransport: ServerURI is not set in ServerConfig")
+// The Extension field of the ServerIdentifier must be a ServerIdentifierExtension.
+func (b *Builder) Build(si clients.ServerIdentifier) (clients.Transport, error) {
+	if si.ServerURI == "" {
+		return nil, fmt.Errorf("grpctransport: ServerURI is not set in ServerIdentifier")
 	}
-	if sc.Extensions == nil {
-		return nil, fmt.Errorf("grpctransport: Extensions is not set in ServerConfig")
+	if si.Extensions == nil {
+		return nil, fmt.Errorf("grpctransport: Extensions is not set in ServerIdentifier")
 	}
-	sce, ok := sc.Extensions.(ServerConfigExtension)
+	sce, ok := si.Extensions.(ServerIdentifierExtension)
 	if !ok {
-		return nil, fmt.Errorf("grpctransport: Extensions field is %T, but must be %T in ServerConfig", sc.Extensions, ServerConfigExtension{})
+		return nil, fmt.Errorf("grpctransport: Extensions field is %T, but must be %T in ServerIdentifier", si.Extensions, ServerIdentifierExtension{})
 	}
 	if sce.Credentials == nil {
-		return nil, fmt.Errorf("grptransport: Credentials field is not set in ServerConfigExtension")
+		return nil, fmt.Errorf("grptransport: Credentials field is not set in ServerIdentifierExtension")
 	}
 
 	// TODO: Incorporate reference count map for existing transports and
-	// deduplicate transports based on the provided ServerConfig so that
+	// deduplicate transports based on the provided ServerIdentifier so that
 	// transport channel to same server can be shared between xDS and LRS
 	// client.
 
@@ -74,9 +75,9 @@ func (b *Builder) Build(sc clients.ServerConfig) (clients.Transport, error) {
 		Time:    5 * time.Minute,
 		Timeout: 20 * time.Second,
 	})
-	cc, err := grpc.NewClient(sc.ServerURI, kpCfg, grpc.WithCredentialsBundle(sce.Credentials), grpc.WithDefaultCallOptions(grpc.ForceCodec(&byteCodec{})))
+	cc, err := grpc.NewClient(si.ServerURI, kpCfg, grpc.WithCredentialsBundle(sce.Credentials), grpc.WithDefaultCallOptions(grpc.ForceCodec(&byteCodec{})))
 	if err != nil {
-		return nil, fmt.Errorf("grpctransport: failed to create transport to server %q: %v", sc.ServerURI, err)
+		return nil, fmt.Errorf("grpctransport: failed to create transport to server %q: %v", si.ServerURI, err)
 	}
 
 	return &grpcTransport{cc: cc}, nil

--- a/xds/internal/clients/grpctransport/grpc_transport_test.go
+++ b/xds/internal/clients/grpctransport/grpc_transport_test.go
@@ -31,7 +31,9 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/credentials/local"
 	"google.golang.org/grpc/internal/grpctest"
+
 	"google.golang.org/grpc/xds/internal/clients"
+
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
@@ -105,6 +107,8 @@ func (s *testServer) StreamAggregatedResources(stream v3discoverygrpc.Aggregated
 			return err // Handle other errors
 		}
 
+		// Push received request for client to verify the correct request was
+		// received.
 		select {
 		case s.requestChan <- req:
 		case <-ctx.Done():
@@ -130,9 +134,9 @@ func (tc *testCredentials) TransportCredentials() credentials.TransportCredentia
 // TestBuild_Success verifies that the Builder successfully creates a new
 // Transport with a non-nil grpc.ClientConn.
 func (s) TestBuild_Success(t *testing.T) {
-	serverCfg := clients.ServerConfig{
+	serverCfg := clients.ServerIdentifier{
 		ServerURI:  "server-address",
-		Extensions: ServerConfigExtension{Credentials: &testCredentials{transportCredentials: local.NewCredentials()}},
+		Extensions: ServerIdentifierExtension{Credentials: &testCredentials{transportCredentials: local.NewCredentials()}},
 	}
 
 	b := &Builder{}
@@ -151,41 +155,41 @@ func (s) TestBuild_Success(t *testing.T) {
 }
 
 // TestBuild_Failure verifies that the Builder returns error when incorrect
-// ServerConfig is provided.
+// ServerIdentifier is provided.
 //
 // It covers the following scenarios:
 // - ServerURI is empty.
 // - Extensions is nil.
-// - Extensions is not ServerConfigExtension.
+// - Extensions is not ServerIdentifierExtension.
 // - Credentials are nil.
 func (s) TestBuild_Failure(t *testing.T) {
 	tests := []struct {
 		name      string
-		serverCfg clients.ServerConfig
+		serverCfg clients.ServerIdentifier
 	}{
 		{
 			name: "ServerURI is empty",
-			serverCfg: clients.ServerConfig{
+			serverCfg: clients.ServerIdentifier{
 				ServerURI:  "",
-				Extensions: ServerConfigExtension{Credentials: insecure.NewBundle()},
+				Extensions: ServerIdentifierExtension{Credentials: insecure.NewBundle()},
 			},
 		},
 		{
 			name:      "Extensions is nil",
-			serverCfg: clients.ServerConfig{ServerURI: "server-address"},
+			serverCfg: clients.ServerIdentifier{ServerURI: "server-address"},
 		},
 		{
-			name: "Extensions is not a ServerConfigExtension",
-			serverCfg: clients.ServerConfig{
+			name: "Extensions is not a ServerIdentifierExtension",
+			serverCfg: clients.ServerIdentifier{
 				ServerURI:  "server-address",
 				Extensions: 1,
 			},
 		},
 		{
-			name: "ServerConfigExtension Credentials is nil",
-			serverCfg: clients.ServerConfig{
+			name: "ServerIdentifierExtension Credentials is nil",
+			serverCfg: clients.ServerIdentifier{
 				ServerURI:  "server-address",
-				Extensions: ServerConfigExtension{},
+				Extensions: ServerIdentifierExtension{},
 			},
 		},
 	}
@@ -208,9 +212,9 @@ func (s) TestBuild_Failure(t *testing.T) {
 func (s) TestNewStream_Success(t *testing.T) {
 	ts := setupTestServer(t, &v3discoverypb.DiscoveryResponse{VersionInfo: "1"})
 
-	serverCfg := clients.ServerConfig{
+	serverCfg := clients.ServerIdentifier{
 		ServerURI:  ts.address,
-		Extensions: ServerConfigExtension{Credentials: insecure.NewBundle()},
+		Extensions: ServerIdentifierExtension{Credentials: insecure.NewBundle()},
 	}
 	builder := Builder{}
 	transport, err := builder.Build(serverCfg)
@@ -229,9 +233,9 @@ func (s) TestNewStream_Success(t *testing.T) {
 // TestNewStream_Error verifies that NewStream() returns an error
 // when attempting to create a stream with an invalid server URI.
 func (s) TestNewStream_Error(t *testing.T) {
-	serverCfg := clients.ServerConfig{
+	serverCfg := clients.ServerIdentifier{
 		ServerURI:  "invalid-server-uri",
-		Extensions: ServerConfigExtension{Credentials: insecure.NewBundle()},
+		Extensions: ServerIdentifierExtension{Credentials: insecure.NewBundle()},
 	}
 	builder := Builder{}
 	transport, err := builder.Build(serverCfg)
@@ -262,9 +266,9 @@ func (s) TestStream_SendAndRecv(t *testing.T) {
 	ts := setupTestServer(t, &v3discoverypb.DiscoveryResponse{VersionInfo: "1"})
 
 	// Build a grpc-based transport to the above server.
-	serverCfg := clients.ServerConfig{
+	serverCfg := clients.ServerIdentifier{
 		ServerURI:  ts.address,
-		Extensions: ServerConfigExtension{Credentials: insecure.NewBundle()},
+		Extensions: ServerIdentifierExtension{Credentials: insecure.NewBundle()},
 	}
 	builder := Builder{}
 	transport, err := builder.Build(serverCfg)

--- a/xds/internal/clients/internal/backoff/backoff.go
+++ b/xds/internal/clients/internal/backoff/backoff.go
@@ -1,0 +1,109 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package backoff implement the backoff strategy for clients.
+//
+// This is kept in internal until the clients project decides whether or not to
+// allow alternative backoff strategies.
+package backoff
+
+import (
+	"context"
+	"errors"
+	rand "math/rand/v2"
+	"time"
+
+	clientsbackoff "google.golang.org/grpc/xds/internal/clients/backoff"
+)
+
+// Strategy defines the methodology for backing off after a grpc connection
+// failure.
+type Strategy interface {
+	// Backoff returns the amount of time to wait before the next retry given
+	// the number of consecutive failures.
+	Backoff(retries int) time.Duration
+}
+
+// DefaultExponential is an exponential backoff implementation using the
+// default values for all the configurable knobs defined in
+// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+var DefaultExponential = Exponential{Config: clientsbackoff.DefaultConfig}
+
+// Exponential implements exponential backoff algorithm as defined in
+// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
+type Exponential struct {
+	// Config contains all options to configure the backoff algorithm.
+	Config clientsbackoff.Config
+}
+
+// Backoff returns the amount of time to wait before the next retry given the
+// number of retries.
+func (bc Exponential) Backoff(retries int) time.Duration {
+	if retries == 0 {
+		return bc.Config.BaseDelay
+	}
+	backoff, max := float64(bc.Config.BaseDelay), float64(bc.Config.MaxDelay)
+	for backoff < max && retries > 0 {
+		backoff *= bc.Config.Multiplier
+		retries--
+	}
+	if backoff > max {
+		backoff = max
+	}
+	// Randomize backoff delays so that if a cluster of requests start at
+	// the same time, they won't operate in lockstep.
+	backoff *= 1 + bc.Config.Jitter*(rand.Float64()*2-1)
+	if backoff < 0 {
+		return 0
+	}
+	return time.Duration(backoff)
+}
+
+// ErrResetBackoff is the error to be returned by the function executed by RunF,
+// to instruct the latter to reset its backoff state.
+var ErrResetBackoff = errors.New("reset backoff state")
+
+// RunF provides a convenient way to run a function f repeatedly until the
+// context expires or f returns a non-nil error that is not ErrResetBackoff.
+// When f returns ErrResetBackoff, RunF continues to run f, but resets its
+// backoff state before doing so. backoff accepts an integer representing the
+// number of retries, and returns the amount of time to backoff.
+func RunF(ctx context.Context, f func() error, backoff func(int) time.Duration) {
+	attempt := 0
+	timer := time.NewTimer(0)
+	for ctx.Err() == nil {
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		}
+
+		err := f()
+		if errors.Is(err, ErrResetBackoff) {
+			timer.Reset(0)
+			attempt = 0
+			continue
+		}
+		if err != nil {
+			return
+		}
+		timer.Reset(backoff(attempt))
+		attempt++
+	}
+}

--- a/xds/internal/clients/internal/buffer/unbounded.go
+++ b/xds/internal/clients/internal/buffer/unbounded.go
@@ -1,0 +1,117 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package buffer provides an implementation of an unbounded buffer.
+package buffer
+
+import (
+	"errors"
+	"sync"
+)
+
+// Unbounded is an implementation of an unbounded buffer which does not use
+// extra goroutines. This is typically used for passing updates from one entity
+// to another within gRPC.
+//
+// All methods on this type are thread-safe and don't block on anything except
+// the underlying mutex used for synchronization.
+//
+// Unbounded supports values of any type to be stored in it by using a channel
+// of `any`. This means that a call to Put() incurs an extra memory allocation,
+// and also that users need a type assertion while reading. For performance
+// critical code paths, using Unbounded is strongly discouraged and defining a
+// new type specific implementation of this buffer is preferred. See
+// internal/transport/transport.go for an example of this.
+type Unbounded struct {
+	c       chan any
+	closed  bool
+	closing bool
+	mu      sync.Mutex
+	backlog []any
+}
+
+// NewUnbounded returns a new instance of Unbounded.
+func NewUnbounded() *Unbounded {
+	return &Unbounded{c: make(chan any, 1)}
+}
+
+var errBufferClosed = errors.New("Put called on closed buffer.Unbounded")
+
+// Put adds t to the unbounded buffer.
+func (b *Unbounded) Put(t any) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closing {
+		return errBufferClosed
+	}
+	if len(b.backlog) == 0 {
+		select {
+		case b.c <- t:
+			return nil
+		default:
+		}
+	}
+	b.backlog = append(b.backlog, t)
+	return nil
+}
+
+// Load sends the earliest buffered data, if any, onto the read channel returned
+// by Get(). Users are expected to call this every time they successfully read a
+// value from the read channel.
+func (b *Unbounded) Load() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.backlog) > 0 {
+		select {
+		case b.c <- b.backlog[0]:
+			b.backlog[0] = nil
+			b.backlog = b.backlog[1:]
+		default:
+		}
+	} else if b.closing && !b.closed {
+		close(b.c)
+	}
+}
+
+// Get returns a read channel on which values added to the buffer, via Put(),
+// are sent on.
+//
+// Upon reading a value from this channel, users are expected to call Load() to
+// send the next buffered value onto the channel if there is any.
+//
+// If the unbounded buffer is closed, the read channel returned by this method
+// is closed after all data is drained.
+func (b *Unbounded) Get() <-chan any {
+	return b.c
+}
+
+// Close closes the unbounded buffer. No subsequent data may be Put(), and the
+// channel returned from Get() will be closed after all the data is read and
+// Load() is called for the final time.
+func (b *Unbounded) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closing {
+		return
+	}
+	b.closing = true
+	if len(b.backlog) == 0 {
+		b.closed = true
+		close(b.c)
+	}
+}

--- a/xds/internal/clients/internal/buffer/unbounded_test.go
+++ b/xds/internal/clients/internal/buffer/unbounded_test.go
@@ -1,0 +1,149 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package buffer
+
+import (
+	"reflect"
+	"sort"
+	"sync"
+	"testing"
+
+	"google.golang.org/grpc/internal/grpctest"
+)
+
+const (
+	numWriters = 10
+	numWrites  = 10
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+// wantReads contains the set of values expected to be read by the reader
+// goroutine in the tests.
+var wantReads []int
+
+func init() {
+	for i := 0; i < numWriters; i++ {
+		for j := 0; j < numWrites; j++ {
+			wantReads = append(wantReads, i)
+		}
+	}
+}
+
+// TestSingleWriter starts one reader and one writer goroutine and makes sure
+// that the reader gets all the values added to the buffer by the writer.
+func (s) TestSingleWriter(t *testing.T) {
+	ub := NewUnbounded()
+	reads := []int{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ch := ub.Get()
+		for i := 0; i < numWriters*numWrites; i++ {
+			r := <-ch
+			reads = append(reads, r.(int))
+			ub.Load()
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numWriters; i++ {
+			for j := 0; j < numWrites; j++ {
+				ub.Put(i)
+			}
+		}
+	}()
+
+	wg.Wait()
+	if !reflect.DeepEqual(reads, wantReads) {
+		t.Errorf("reads: %#v, wantReads: %#v", reads, wantReads)
+	}
+}
+
+// TestMultipleWriters starts multiple writers and one reader goroutine and
+// makes sure that the reader gets all the data written by all writers.
+func (s) TestMultipleWriters(t *testing.T) {
+	ub := NewUnbounded()
+	reads := []int{}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ch := ub.Get()
+		for i := 0; i < numWriters*numWrites; i++ {
+			r := <-ch
+			reads = append(reads, r.(int))
+			ub.Load()
+		}
+	}()
+
+	wg.Add(numWriters)
+	for i := 0; i < numWriters; i++ {
+		go func(index int) {
+			defer wg.Done()
+			for j := 0; j < numWrites; j++ {
+				ub.Put(index)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	sort.Ints(reads)
+	if !reflect.DeepEqual(reads, wantReads) {
+		t.Errorf("reads: %#v, wantReads: %#v", reads, wantReads)
+	}
+}
+
+// TestClose closes the buffer and makes sure that nothing is sent after the
+// buffer is closed.
+func (s) TestClose(t *testing.T) {
+	ub := NewUnbounded()
+	if err := ub.Put(1); err != nil {
+		t.Fatalf("Unbounded.Put() = %v; want nil", err)
+	}
+	ub.Close()
+	if err := ub.Put(1); err == nil {
+		t.Fatalf("Unbounded.Put() = <nil>; want non-nil error")
+	}
+	if v, ok := <-ub.Get(); !ok {
+		t.Errorf("Unbounded.Get() = %v, %v, want %v, %v", v, ok, 1, true)
+	}
+	if err := ub.Put(1); err == nil {
+		t.Fatalf("Unbounded.Put() = <nil>; want non-nil error")
+	}
+	ub.Load()
+	if v, ok := <-ub.Get(); ok {
+		t.Errorf("Unbounded.Get() = %v, want closed channel", v)
+	}
+	if err := ub.Put(1); err == nil {
+		t.Fatalf("Unbounded.Put() = <nil>; want non-nil error")
+	}
+	ub.Close() // ignored
+}

--- a/xds/internal/clients/internal/clientslog/prefix_logger.go
+++ b/xds/internal/clients/internal/clientslog/prefix_logger.go
@@ -1,0 +1,79 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package clientslog provides logging functionality for internal clients packages,
+// outside of the functionality provided by the external `clientslog` package.
+package clientslog
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/xds/internal/clients/clientslog"
+)
+
+// PrefixLogger does logging with a prefix.
+//
+// Logging method on a nil logs without any prefix.
+type PrefixLogger struct {
+	logger clientslog.DepthLoggerV2
+	prefix string
+}
+
+// Infof does info logging.
+func (pl *PrefixLogger) Infof(format string, args ...any) {
+	if pl != nil {
+		// Handle nil, so the tests can pass in a nil logger.
+		format = pl.prefix + format
+		pl.logger.InfoDepth(1, fmt.Sprintf(format, args...))
+		return
+	}
+	clientslog.InfoDepth(1, fmt.Sprintf(format, args...))
+}
+
+// Warningf does warning logging.
+func (pl *PrefixLogger) Warningf(format string, args ...any) {
+	if pl != nil {
+		format = pl.prefix + format
+		pl.logger.WarningDepth(1, fmt.Sprintf(format, args...))
+		return
+	}
+	clientslog.WarningDepth(1, fmt.Sprintf(format, args...))
+}
+
+// Errorf does error logging.
+func (pl *PrefixLogger) Errorf(format string, args ...any) {
+	if pl != nil {
+		format = pl.prefix + format
+		pl.logger.ErrorDepth(1, fmt.Sprintf(format, args...))
+		return
+	}
+	clientslog.ErrorDepth(1, fmt.Sprintf(format, args...))
+}
+
+// V reports whether verbosity level l is at least the requested verbose level.
+func (pl *PrefixLogger) V(l int) bool {
+	if pl != nil {
+		return pl.logger.V(l)
+	}
+	return true
+}
+
+// NewPrefixLogger creates a prefix logger with the given prefix.
+func NewPrefixLogger(logger clientslog.DepthLoggerV2, prefix string) *PrefixLogger {
+	return &PrefixLogger{logger: logger, prefix: prefix}
+}

--- a/xds/internal/clients/internal/clientssync/callback_serializer.go
+++ b/xds/internal/clients/internal/clientssync/callback_serializer.go
@@ -1,0 +1,112 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clientssync
+
+import (
+	"context"
+
+	"google.golang.org/grpc/xds/internal/clients/internal/buffer"
+)
+
+// CallbackSerializer provides a mechanism to schedule callbacks in a
+// synchronized manner. It provides a FIFO guarantee on the order of execution
+// of scheduled callbacks. New callbacks can be scheduled by invoking the
+// Schedule() method.
+//
+// This type is safe for concurrent access.
+type CallbackSerializer struct {
+	// done is closed once the serializer is shut down completely, i.e all
+	// scheduled callbacks are executed and the serializer has deallocated all
+	// its resources.
+	done chan struct{}
+
+	callbacks *buffer.Unbounded
+}
+
+// NewCallbackSerializer returns a new CallbackSerializer instance. The provided
+// context will be passed to the scheduled callbacks. Users should cancel the
+// provided context to shutdown the CallbackSerializer. It is guaranteed that no
+// callbacks will be added once this context is canceled, and any pending un-run
+// callbacks will be executed before the serializer is shut down.
+func NewCallbackSerializer(ctx context.Context) *CallbackSerializer {
+	cs := &CallbackSerializer{
+		done:      make(chan struct{}),
+		callbacks: buffer.NewUnbounded(),
+	}
+	go cs.run(ctx)
+	return cs
+}
+
+// TrySchedule tries to schedule the provided callback function f to be
+// executed in the order it was added. This is a best-effort operation. If the
+// context passed to NewCallbackSerializer was canceled before this method is
+// called, the callback will not be scheduled.
+//
+// Callbacks are expected to honor the context when performing any blocking
+// operations, and should return early when the context is canceled.
+func (cs *CallbackSerializer) TrySchedule(f func(ctx context.Context)) {
+	cs.callbacks.Put(f)
+}
+
+// ScheduleOr schedules the provided callback function f to be executed in the
+// order it was added. If the context passed to NewCallbackSerializer has been
+// canceled before this method is called, the onFailure callback will be
+// executed inline instead.
+//
+// Callbacks are expected to honor the context when performing any blocking
+// operations, and should return early when the context is canceled.
+func (cs *CallbackSerializer) ScheduleOr(f func(ctx context.Context), onFailure func()) {
+	if cs.callbacks.Put(f) != nil {
+		onFailure()
+	}
+}
+
+func (cs *CallbackSerializer) run(ctx context.Context) {
+	defer close(cs.done)
+
+	// TODO: when Go 1.21 is the oldest supported version, this loop and Close
+	// can be replaced with:
+	//
+	// context.AfterFunc(ctx, cs.callbacks.Close)
+	for ctx.Err() == nil {
+		select {
+		case <-ctx.Done():
+			// Do nothing here. Next iteration of the for loop will not happen,
+			// since ctx.Err() would be non-nil.
+		case cb := <-cs.callbacks.Get():
+			cs.callbacks.Load()
+			cb.(func(context.Context))(ctx)
+		}
+	}
+
+	// Close the buffer to prevent new callbacks from being added.
+	cs.callbacks.Close()
+
+	// Run all pending callbacks.
+	for cb := range cs.callbacks.Get() {
+		cs.callbacks.Load()
+		cb.(func(context.Context))(ctx)
+	}
+}
+
+// Done returns a channel that is closed after the context passed to
+// NewCallbackSerializer is canceled and all callbacks have been executed.
+func (cs *CallbackSerializer) Done() <-chan struct{} {
+	return cs.done
+}

--- a/xds/internal/clients/internal/clientssync/callback_serializer_test.go
+++ b/xds/internal/clients/internal/clientssync/callback_serializer_test.go
@@ -1,0 +1,206 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clientssync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	defaultTestTimeout      = 5 * time.Second
+	defaultTestShortTimeout = 10 * time.Millisecond // For events expected to *not* happen.
+)
+
+// TestCallbackSerializer_Schedule_FIFO verifies that callbacks are executed in
+// the same order in which they were scheduled.
+func (s) TestCallbackSerializer_Schedule_FIFO(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	cs := NewCallbackSerializer(ctx)
+	defer cancel()
+
+	// We have two channels, one to record the order of scheduling, and the
+	// other to record the order of execution. We spawn a bunch of goroutines
+	// which record the order of scheduling and call the actual Schedule()
+	// method as well.  The callbacks record the order of execution.
+	//
+	// We need to grab a lock to record order of scheduling to guarantee that
+	// the act of recording and the act of calling Schedule() happen atomically.
+	const numCallbacks = 100
+	var mu sync.Mutex
+	scheduleOrderCh := make(chan int, numCallbacks)
+	executionOrderCh := make(chan int, numCallbacks)
+	for i := 0; i < numCallbacks; i++ {
+		go func(id int) {
+			mu.Lock()
+			defer mu.Unlock()
+			scheduleOrderCh <- id
+			cs.TrySchedule(func(ctx context.Context) {
+				select {
+				case <-ctx.Done():
+					return
+				case executionOrderCh <- id:
+				}
+			})
+		}(i)
+	}
+
+	// Spawn a couple of goroutines to capture the order or scheduling and the
+	// order of execution.
+	scheduleOrder := make([]int, numCallbacks)
+	executionOrder := make([]int, numCallbacks)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numCallbacks; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case id := <-scheduleOrderCh:
+				scheduleOrder[i] = id
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numCallbacks; i++ {
+			select {
+			case <-ctx.Done():
+				return
+			case id := <-executionOrderCh:
+				executionOrder[i] = id
+			}
+		}
+	}()
+	wg.Wait()
+
+	if diff := cmp.Diff(executionOrder, scheduleOrder); diff != "" {
+		t.Fatalf("Callbacks are not executed in scheduled order. diff(-want, +got):\n%s", diff)
+	}
+}
+
+// TestCallbackSerializer_Schedule_Concurrent verifies that all concurrently
+// scheduled callbacks get executed.
+func (s) TestCallbackSerializer_Schedule_Concurrent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	cs := NewCallbackSerializer(ctx)
+	defer cancel()
+
+	// Schedule callbacks concurrently by calling Schedule() from goroutines.
+	// The execution of the callbacks call Done() on the waitgroup, which
+	// eventually unblocks the test and allows it to complete.
+	const numCallbacks = 100
+	var wg sync.WaitGroup
+	wg.Add(numCallbacks)
+	for i := 0; i < numCallbacks; i++ {
+		go func() {
+			cs.TrySchedule(func(context.Context) {
+				wg.Done()
+			})
+		}()
+	}
+
+	// We call Wait() on the waitgroup from a goroutine so that we can select on
+	// the Wait() being unblocked and the overall test deadline expiring.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Timeout waiting for all scheduled callbacks to be executed")
+	case <-done:
+	}
+}
+
+// TestCallbackSerializer_Schedule_Close verifies that callbacks in the queue
+// are not executed once Close() returns.
+func (s) TestCallbackSerializer_Schedule_Close(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	serializerCtx, serializerCancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	cs := NewCallbackSerializer(serializerCtx)
+
+	// Schedule a callback which blocks until the context passed to it is
+	// canceled. It also closes a channel to signal that it has started.
+	firstCallbackStartedCh := make(chan struct{})
+	cs.TrySchedule(func(ctx context.Context) {
+		close(firstCallbackStartedCh)
+		<-ctx.Done()
+	})
+
+	// Schedule a bunch of callbacks. These should be executed since they are
+	// scheduled before the serializer is closed.
+	const numCallbacks = 10
+	callbackCh := make(chan int, numCallbacks)
+	for i := 0; i < numCallbacks; i++ {
+		num := i
+		callback := func(context.Context) { callbackCh <- num }
+		onFailure := func() { t.Fatal("Schedule failed to accept a callback when the serializer is yet to be closed") }
+		cs.ScheduleOr(callback, onFailure)
+	}
+
+	// Ensure that none of the newer callbacks are executed at this point.
+	select {
+	case <-time.After(defaultTestShortTimeout):
+	case <-callbackCh:
+		t.Fatal("Newer callback executed when older one is still executing")
+	}
+
+	// Wait for the first callback to start before closing the scheduler.
+	<-firstCallbackStartedCh
+
+	// Cancel the context which will unblock the first callback. All of the
+	// other callbacks (which have not started executing at this point) should
+	// be executed after this.
+	serializerCancel()
+
+	// Ensure that the newer callbacks are executed.
+	for i := 0; i < numCallbacks; i++ {
+		select {
+		case <-ctx.Done():
+			t.Fatal("Timeout when waiting for callback scheduled before close to be executed")
+		case num := <-callbackCh:
+			if num != i {
+				t.Fatalf("Executing callback %d, want %d", num, i)
+			}
+		}
+	}
+	<-cs.Done()
+
+	// Ensure that a callback cannot be scheduled after the serializer is
+	// closed.
+	done := make(chan struct{})
+	callback := func(context.Context) { t.Fatal("Scheduled a callback after closing the serializer") }
+	onFailure := func() { close(done) }
+	cs.ScheduleOr(callback, onFailure)
+	select {
+	case <-time.After(defaultTestTimeout):
+		t.Fatal("Successfully scheduled callback after serializer is closed")
+	case <-done:
+	}
+}

--- a/xds/internal/clients/internal/clientssync/event.go
+++ b/xds/internal/clients/internal/clientssync/event.go
@@ -1,0 +1,61 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package clientssync implements additional synchronization primitives built upon
+// the sync package.
+package clientssync
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Event represents a one-time event that may occur in the future.
+type Event struct {
+	fired int32
+	c     chan struct{}
+	o     sync.Once
+}
+
+// Fire causes e to complete.  It is safe to call multiple times, and
+// concurrently.  It returns true iff this call to Fire caused the signaling
+// channel returned by Done to close.
+func (e *Event) Fire() bool {
+	ret := false
+	e.o.Do(func() {
+		atomic.StoreInt32(&e.fired, 1)
+		close(e.c)
+		ret = true
+	})
+	return ret
+}
+
+// Done returns a channel that will be closed when Fire is called.
+func (e *Event) Done() <-chan struct{} {
+	return e.c
+}
+
+// HasFired returns true if Fire has been called.
+func (e *Event) HasFired() bool {
+	return atomic.LoadInt32(&e.fired) == 1
+}
+
+// NewEvent returns a new, ready-to-use Event.
+func NewEvent() *Event {
+	return &Event{c: make(chan struct{})}
+}

--- a/xds/internal/clients/internal/clientssync/event_test.go
+++ b/xds/internal/clients/internal/clientssync/event_test.go
@@ -1,0 +1,81 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clientssync
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/internal/grpctest"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+func (s) TestEventHasFired(t *testing.T) {
+	e := NewEvent()
+	if e.HasFired() {
+		t.Fatal("e.HasFired() = true; want false")
+	}
+	if !e.Fire() {
+		t.Fatal("e.Fire() = false; want true")
+	}
+	if !e.HasFired() {
+		t.Fatal("e.HasFired() = false; want true")
+	}
+}
+
+func (s) TestEventDoneChannel(t *testing.T) {
+	e := NewEvent()
+	select {
+	case <-e.Done():
+		t.Fatal("e.HasFired() = true; want false")
+	default:
+	}
+	if !e.Fire() {
+		t.Fatal("e.Fire() = false; want true")
+	}
+	select {
+	case <-e.Done():
+	default:
+		t.Fatal("e.HasFired() = false; want true")
+	}
+}
+
+func (s) TestEventMultipleFires(t *testing.T) {
+	e := NewEvent()
+	if e.HasFired() {
+		t.Fatal("e.HasFired() = true; want false")
+	}
+	if !e.Fire() {
+		t.Fatal("e.Fire() = false; want true")
+	}
+	for i := 0; i < 3; i++ {
+		if !e.HasFired() {
+			t.Fatal("e.HasFired() = false; want true")
+		}
+		if e.Fire() {
+			t.Fatal("e.Fire() = true; want false")
+		}
+	}
+}

--- a/xds/internal/clients/internal/clientssync/pubsub.go
+++ b/xds/internal/clients/internal/clientssync/pubsub.go
@@ -1,0 +1,121 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clientssync
+
+import (
+	"context"
+	"sync"
+)
+
+// Subscriber represents an entity that is subscribed to messages published on
+// a PubSub. It wraps the callback to be invoked by the PubSub when a new
+// message is published.
+type Subscriber interface {
+	// OnMessage is invoked when a new message is published. Implementations
+	// must not block in this method.
+	OnMessage(msg any)
+}
+
+// PubSub is a simple one-to-many publish-subscribe system that supports
+// messages of arbitrary type. It guarantees that messages are delivered in
+// the same order in which they were published.
+//
+// Publisher invokes the Publish() method to publish new messages, while
+// subscribers interested in receiving these messages register a callback
+// via the Subscribe() method.
+//
+// Once a PubSub is stopped, no more messages can be published, but any pending
+// published messages will be delivered to the subscribers.  Done may be used
+// to determine when all published messages have been delivered.
+type PubSub struct {
+	cs *CallbackSerializer
+
+	// Access to the below fields are guarded by this mutex.
+	mu          sync.Mutex
+	msg         any
+	subscribers map[Subscriber]bool
+}
+
+// NewPubSub returns a new PubSub instance.  Users should cancel the
+// provided context to shutdown the PubSub.
+func NewPubSub(ctx context.Context) *PubSub {
+	return &PubSub{
+		cs:          NewCallbackSerializer(ctx),
+		subscribers: map[Subscriber]bool{},
+	}
+}
+
+// Subscribe registers the provided Subscriber to the PubSub.
+//
+// If the PubSub contains a previously published message, the Subscriber's
+// OnMessage() callback will be invoked asynchronously with the existing
+// message to begin with, and subsequently for every newly published message.
+//
+// The caller is responsible for invoking the returned cancel function to
+// unsubscribe itself from the PubSub.
+func (ps *PubSub) Subscribe(sub Subscriber) (cancel func()) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	ps.subscribers[sub] = true
+
+	if ps.msg != nil {
+		msg := ps.msg
+		ps.cs.TrySchedule(func(context.Context) {
+			ps.mu.Lock()
+			defer ps.mu.Unlock()
+			if !ps.subscribers[sub] {
+				return
+			}
+			sub.OnMessage(msg)
+		})
+	}
+
+	return func() {
+		ps.mu.Lock()
+		defer ps.mu.Unlock()
+		delete(ps.subscribers, sub)
+	}
+}
+
+// Publish publishes the provided message to the PubSub, and invokes
+// callbacks registered by subscribers asynchronously.
+func (ps *PubSub) Publish(msg any) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	ps.msg = msg
+	for sub := range ps.subscribers {
+		s := sub
+		ps.cs.TrySchedule(func(context.Context) {
+			ps.mu.Lock()
+			defer ps.mu.Unlock()
+			if !ps.subscribers[s] {
+				return
+			}
+			s.OnMessage(msg)
+		})
+	}
+}
+
+// Done returns a channel that is closed after the context passed to NewPubSub
+// is canceled and all updates have been sent to subscribers.
+func (ps *PubSub) Done() <-chan struct{} {
+	return ps.cs.Done()
+}

--- a/xds/internal/clients/internal/clientssync/pubsub_test.go
+++ b/xds/internal/clients/internal/clientssync/pubsub_test.go
@@ -1,0 +1,196 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clientssync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+type testSubscriber struct {
+	onMsgCh chan int
+}
+
+func newTestSubscriber(chSize int) *testSubscriber {
+	return &testSubscriber{onMsgCh: make(chan int, chSize)}
+}
+
+func (ts *testSubscriber) OnMessage(msg any) {
+	select {
+	case ts.onMsgCh <- msg.(int):
+	default:
+	}
+}
+
+func (s) TestPubSub_PublishNoMsg(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	pubsub := NewPubSub(ctx)
+
+	ts := newTestSubscriber(1)
+	pubsub.Subscribe(ts)
+
+	select {
+	case <-ts.onMsgCh:
+		t.Fatal("Subscriber callback invoked when no message was published")
+	case <-time.After(defaultTestShortTimeout):
+	}
+}
+
+func (s) TestPubSub_PublishMsgs_RegisterSubs_And_Stop(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	pubsub := NewPubSub(ctx)
+
+	const numPublished = 10
+
+	ts1 := newTestSubscriber(numPublished)
+	pubsub.Subscribe(ts1)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	// Publish ten messages on the pubsub and ensure that they are received in order by the subscriber.
+	go func() {
+		for i := 0; i < numPublished; i++ {
+			pubsub.Publish(i)
+		}
+		wg.Done()
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numPublished; i++ {
+			select {
+			case m := <-ts1.onMsgCh:
+				if m != i {
+					t.Errorf("Received unexpected message: %q; want: %q", m, i)
+					return
+				}
+			case <-time.After(defaultTestTimeout):
+				t.Error("Timeout when expecting the onMessage() callback to be invoked")
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	// Register another subscriber and ensure that it receives the last published message.
+	ts2 := newTestSubscriber(numPublished)
+	pubsub.Subscribe(ts2)
+
+	select {
+	case m := <-ts2.onMsgCh:
+		if m != numPublished-1 {
+			t.Fatalf("Received unexpected message: %q; want: %q", m, numPublished-1)
+		}
+	case <-time.After(defaultTestShortTimeout):
+		t.Fatal("Timeout when expecting the onMessage() callback to be invoked")
+	}
+
+	wg.Add(3)
+	// Publish ten messages on the pubsub and ensure that they are received in order by the subscribers.
+	go func() {
+		for i := 0; i < numPublished; i++ {
+			pubsub.Publish(i)
+		}
+		wg.Done()
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numPublished; i++ {
+			select {
+			case m := <-ts1.onMsgCh:
+				if m != i {
+					t.Errorf("Received unexpected message: %q; want: %q", m, i)
+					return
+				}
+			case <-time.After(defaultTestTimeout):
+				t.Error("Timeout when expecting the onMessage() callback to be invoked")
+				return
+			}
+		}
+
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numPublished; i++ {
+			select {
+			case m := <-ts2.onMsgCh:
+				if m != i {
+					t.Errorf("Received unexpected message: %q; want: %q", m, i)
+					return
+				}
+			case <-time.After(defaultTestTimeout):
+				t.Error("Timeout when expecting the onMessage() callback to be invoked")
+				return
+			}
+		}
+	}()
+	wg.Wait()
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	cancel()
+	<-pubsub.Done()
+
+	go func() {
+		pubsub.Publish(99)
+	}()
+	// Ensure that the subscriber callback is not invoked as instantiated
+	// pubsub has already closed.
+	select {
+	case <-ts1.onMsgCh:
+		t.Fatal("The callback was invoked after pubsub being stopped")
+	case <-ts2.onMsgCh:
+		t.Fatal("The callback was invoked after pubsub being stopped")
+	case <-time.After(defaultTestShortTimeout):
+	}
+}
+
+func (s) TestPubSub_PublishMsgs_BeforeRegisterSub(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+	pubsub := NewPubSub(ctx)
+
+	const numPublished = 3
+	for i := 0; i < numPublished; i++ {
+		pubsub.Publish(i)
+	}
+
+	ts := newTestSubscriber(numPublished)
+	pubsub.Subscribe(ts)
+
+	// Ensure that the subscriber callback is invoked with a previously
+	// published message.
+	select {
+	case d := <-ts.onMsgCh:
+		if d != numPublished-1 {
+			t.Fatalf("Unexpected message received: %q; %q", d, numPublished-1)
+		}
+
+	case <-time.After(defaultTestShortTimeout):
+		t.Fatal("Timeout when expecting the onMessage() callback to be invoked")
+	}
+}

--- a/xds/internal/clients/internal/clientsutils/clientsutils.go
+++ b/xds/internal/clients/internal/clientsutils/clientsutils.go
@@ -1,0 +1,107 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package clientsutils contains helpers for xDS and LRS clients.
+package clientsutils
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"google.golang.org/grpc/xds/internal/clients"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+)
+
+// ServerIdentifierString returns a string representation of the
+// clients.ServerIdentifier si.
+//
+// WARNING: This method is primarily intended for logging and testing
+// purposes. The output returned by this method is not guaranteed to be stable
+// and may change at any time. Do not rely on it for production use.
+func ServerIdentifierString(si clients.ServerIdentifier) string {
+	return strings.Join([]string{si.ServerURI, fmt.Sprintf("%v", si.Extensions)}, "-")
+}
+
+// IsServerIdentifierEqual returns true if clients.ServerIdentifier si1 and si2
+// are considered equal.
+func IsServerIdentifierEqual(si1, si2 *clients.ServerIdentifier) bool {
+	switch {
+	case si1 == nil && si2 == nil:
+		return true
+	case (si1 != nil) != (si2 != nil):
+		return false
+	case si1.ServerURI != si2.ServerURI:
+		return false
+	}
+	if si1.Extensions == nil && si2.Extensions == nil {
+		return true
+	}
+	if ex, ok := si1.Extensions.(interface{ Equal(any) bool }); ok && ex.Equal(si2.Extensions) {
+		return true
+	}
+	return false
+}
+
+// NodeProto returns a protobuf representation of clients.Node n
+// and client features cf.
+//
+// This function is intended to be used by the xDS client implementation to
+// convert the user-provided Node configuration to its protobuf representation.
+func NodeProto(n clients.Node, cf []string) *v3corepb.Node {
+	return &v3corepb.Node{
+		Id:      n.ID,
+		Cluster: n.Cluster,
+		Locality: func() *v3corepb.Locality {
+			if IsLocalityEmpty(n.Locality) {
+				return nil
+			}
+			return &v3corepb.Locality{
+				Region:  n.Locality.Region,
+				Zone:    n.Locality.Zone,
+				SubZone: n.Locality.SubZone,
+			}
+		}(),
+		Metadata: func() *structpb.Struct {
+			if n.Metadata == nil {
+				return nil
+			}
+			if md, ok := n.Metadata.(*structpb.Struct); ok {
+				return proto.Clone(md).(*structpb.Struct)
+			}
+			return nil
+		}(),
+		UserAgentName:        n.UserAgentName,
+		UserAgentVersionType: &v3corepb.Node_UserAgentVersion{UserAgentVersion: n.UserAgentVersion},
+		ClientFeatures:       slices.Clone(cf),
+	}
+}
+
+// IsLocalityEmpty reports whether clients.Locality l is considered empty.
+func IsLocalityEmpty(l clients.Locality) bool {
+	return IsLocalityEqual(l, clients.Locality{})
+}
+
+// IsLocalityEqual returns true if clients.Locality l1 and l2 are considered
+// equal.
+func IsLocalityEqual(l1, l2 clients.Locality) bool {
+	return l1.Region == l2.Region && l1.Zone == l2.Zone && l1.SubZone == l2.SubZone
+}

--- a/xds/internal/clients/internal/clientsutils/clientsutils_test.go
+++ b/xds/internal/clients/internal/clientsutils/clientsutils_test.go
@@ -16,16 +16,20 @@
  *
  */
 
-package clients
+package clientsutils
 
 import (
 	"testing"
 
-	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/go-cmp/cmp"
+
 	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/xds/internal/clients"
+
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
 
 type s struct {
@@ -36,10 +40,10 @@ func Test(t *testing.T) {
 	grpctest.RunSubTests(t, s{})
 }
 
-type testServerConfigExtension struct{ x int }
+type testServerIdentifierExtension struct{ x int }
 
-func (ts testServerConfigExtension) Equal(other any) bool {
-	ots, ok := other.(testServerConfigExtension)
+func (ts testServerIdentifierExtension) Equal(other any) bool {
+	ots, ok := other.(testServerIdentifierExtension)
 	if !ok {
 		return false
 	}
@@ -56,11 +60,11 @@ func newStructProtoFromMap(t *testing.T, input map[string]any) *structpb.Struct 
 	return ret
 }
 
-func (s) TestServerConfig_Equal(t *testing.T) {
+func (s) TestIsServerIdentifierEqual(t *testing.T) {
 	tests := []struct {
 		name   string
-		s1     *ServerConfig
-		s2     *ServerConfig
+		s1     *clients.ServerIdentifier
+		s2     *clients.ServerIdentifier
 		wantEq bool
 	}{
 		{
@@ -72,104 +76,96 @@ func (s) TestServerConfig_Equal(t *testing.T) {
 		{
 			name:   "one_nil",
 			s1:     nil,
-			s2:     &ServerConfig{},
+			s2:     &clients.ServerIdentifier{},
 			wantEq: false,
 		},
 		{
 			name:   "other_nil",
-			s1:     &ServerConfig{},
+			s1:     &clients.ServerIdentifier{},
 			s2:     nil,
 			wantEq: false,
 		},
 		{
 			name:   "both_empty_and_equal",
-			s1:     &ServerConfig{},
-			s2:     &ServerConfig{},
+			s1:     &clients.ServerIdentifier{},
+			s2:     &clients.ServerIdentifier{},
 			wantEq: true,
 		},
 		{
 			name:   "different_ServerURI",
-			s1:     &ServerConfig{ServerURI: "foo"},
-			s2:     &ServerConfig{ServerURI: "bar"},
-			wantEq: false,
-		},
-		{
-			name:   "different_IgnoreResourceDeletion",
-			s1:     &ServerConfig{IgnoreResourceDeletion: true},
-			s2:     &ServerConfig{},
+			s1:     &clients.ServerIdentifier{ServerURI: "foo"},
+			s2:     &clients.ServerIdentifier{ServerURI: "bar"},
 			wantEq: false,
 		},
 		{
 			name: "different_Extensions_with_no_Equal_method",
-			s1: &ServerConfig{
+			s1: &clients.ServerIdentifier{
 				Extensions: 1,
 			},
-			s2: &ServerConfig{
+			s2: &clients.ServerIdentifier{
 				Extensions: 2,
 			},
 			wantEq: false, // By default, if there's no Equal method, they are unequal
 		},
 		{
 			name: "same_Extensions_with_no_Equal_method",
-			s1: &ServerConfig{
+			s1: &clients.ServerIdentifier{
 				Extensions: 1,
 			},
-			s2: &ServerConfig{
+			s2: &clients.ServerIdentifier{
 				Extensions: 1,
 			},
 			wantEq: false, // By default, if there's no Equal method, they are unequal
 		},
 		{
 			name: "different_Extensions_with_Equal_method",
-			s1: &ServerConfig{
-				Extensions: testServerConfigExtension{1},
+			s1: &clients.ServerIdentifier{
+				Extensions: testServerIdentifierExtension{1},
 			},
-			s2: &ServerConfig{
-				Extensions: testServerConfigExtension{2},
+			s2: &clients.ServerIdentifier{
+				Extensions: testServerIdentifierExtension{2},
 			},
 			wantEq: false,
 		},
 		{
 			name: "same_Extensions_same_with_Equal_method",
-			s1: &ServerConfig{
-				Extensions: testServerConfigExtension{1},
+			s1: &clients.ServerIdentifier{
+				Extensions: testServerIdentifierExtension{1},
 			},
-			s2: &ServerConfig{
-				Extensions: testServerConfigExtension{1},
+			s2: &clients.ServerIdentifier{
+				Extensions: testServerIdentifierExtension{1},
 			},
 			wantEq: true,
 		},
 		{
 			name: "first_config_Extensions_is_nil",
-			s1: &ServerConfig{
-				Extensions: testServerConfigExtension{1},
+			s1: &clients.ServerIdentifier{
+				Extensions: testServerIdentifierExtension{1},
 			},
-			s2: &ServerConfig{
+			s2: &clients.ServerIdentifier{
 				Extensions: nil,
 			},
 			wantEq: false,
 		},
 		{
 			name: "other_config_Extensions_is_nil",
-			s1: &ServerConfig{
+			s1: &clients.ServerIdentifier{
 				Extensions: nil,
 			},
-			s2: &ServerConfig{
-				Extensions: testServerConfigExtension{2},
+			s2: &clients.ServerIdentifier{
+				Extensions: testServerIdentifierExtension{2},
 			},
 			wantEq: false,
 		},
 		{
 			name: "all_fields_same",
-			s1: &ServerConfig{
-				ServerURI:              "foo",
-				IgnoreResourceDeletion: true,
-				Extensions:             testServerConfigExtension{1},
+			s1: &clients.ServerIdentifier{
+				ServerURI:  "foo",
+				Extensions: testServerIdentifierExtension{1},
 			},
-			s2: &ServerConfig{
-				ServerURI:              "foo",
-				IgnoreResourceDeletion: true,
-				Extensions:             testServerConfigExtension{1},
+			s2: &clients.ServerIdentifier{
+				ServerURI:  "foo",
+				Extensions: testServerIdentifierExtension{1},
 			},
 			wantEq: true,
 		},
@@ -177,121 +173,122 @@ func (s) TestServerConfig_Equal(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if gotEq := test.s1.equal(test.s2); gotEq != test.wantEq {
+			if gotEq := IsServerIdentifierEqual(test.s1, test.s2); gotEq != test.wantEq {
 				t.Errorf("Equal() = %v, want %v", gotEq, test.wantEq)
 			}
 		})
 	}
 }
 
-func (s) TestLocality_IsEmpty(t *testing.T) {
+func (s) TestIsLocalityEmpty(t *testing.T) {
 	tests := []struct {
 		name     string
-		locality Locality
+		locality clients.Locality
 		want     bool
 	}{
 		{
 			name:     "empty_locality",
-			locality: Locality{},
+			locality: clients.Locality{},
 			want:     true,
 		},
 		{
 			name:     "non_empty_region",
-			locality: Locality{Region: "region"},
+			locality: clients.Locality{Region: "region"},
 			want:     false,
 		},
 		{
 			name:     "non_empty_zone",
-			locality: Locality{Zone: "zone"},
+			locality: clients.Locality{Zone: "zone"},
 			want:     false,
 		},
 		{
 			name:     "non_empty_subzone",
-			locality: Locality{SubZone: "subzone"},
+			locality: clients.Locality{SubZone: "subzone"},
 			want:     false,
 		},
 		{
 			name:     "non_empty_all_fields",
-			locality: Locality{Region: "region", Zone: "zone", SubZone: "subzone"},
+			locality: clients.Locality{Region: "region", Zone: "zone", SubZone: "subzone"},
 			want:     false,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := test.locality.isEmpty(); got != test.want {
+			if got := IsLocalityEmpty(test.locality); got != test.want {
 				t.Errorf("IsEmpty() = %v, want %v", got, test.want)
 			}
 		})
 	}
 }
 
-func (s) TestLocality_Equal(t *testing.T) {
+func (s) TestIsLocalityEqual(t *testing.T) {
 	tests := []struct {
 		name   string
-		l1     Locality
-		l2     Locality
+		l1     clients.Locality
+		l2     clients.Locality
 		wantEq bool
 	}{
 		{
 			name:   "both_equal",
-			l1:     Locality{Region: "region", Zone: "zone", SubZone: "subzone"},
-			l2:     Locality{Region: "region", Zone: "zone", SubZone: "subzone"},
+			l1:     clients.Locality{Region: "region", Zone: "zone", SubZone: "subzone"},
+			l2:     clients.Locality{Region: "region", Zone: "zone", SubZone: "subzone"},
 			wantEq: true,
 		},
 		{
 			name:   "different_regions",
-			l1:     Locality{Region: "region1", Zone: "zone", SubZone: "subzone"},
-			l2:     Locality{Region: "region2", Zone: "zone", SubZone: "subzone"},
+			l1:     clients.Locality{Region: "region1", Zone: "zone", SubZone: "subzone"},
+			l2:     clients.Locality{Region: "region2", Zone: "zone", SubZone: "subzone"},
 			wantEq: false,
 		},
 
 		{
 			name:   "different_zones",
-			l1:     Locality{Region: "region", Zone: "zone1", SubZone: "subzone"},
-			l2:     Locality{Region: "region", Zone: "zone2", SubZone: "subzone"},
+			l1:     clients.Locality{Region: "region", Zone: "zone1", SubZone: "subzone"},
+			l2:     clients.Locality{Region: "region", Zone: "zone2", SubZone: "subzone"},
 			wantEq: false,
 		},
 		{
 			name:   "different_subzones",
-			l1:     Locality{Region: "region", Zone: "zone", SubZone: "subzone1"},
-			l2:     Locality{Region: "region", Zone: "zone", SubZone: "subzone2"},
+			l1:     clients.Locality{Region: "region", Zone: "zone", SubZone: "subzone1"},
+			l2:     clients.Locality{Region: "region", Zone: "zone", SubZone: "subzone2"},
 			wantEq: false,
 		},
 		{
 			name:   "one_empty",
-			l1:     Locality{},
-			l2:     Locality{Region: "region", Zone: "zone", SubZone: "subzone"},
+			l1:     clients.Locality{},
+			l2:     clients.Locality{Region: "region", Zone: "zone", SubZone: "subzone"},
 			wantEq: false,
 		},
 		{
 			name:   "both_empty",
-			l1:     Locality{},
-			l2:     Locality{},
+			l1:     clients.Locality{},
+			l2:     clients.Locality{},
 			wantEq: true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if gotEq := test.l1.equal(test.l2); gotEq != test.wantEq {
+			if gotEq := IsLocalityEqual(test.l1, test.l2); gotEq != test.wantEq {
 				t.Errorf("Equal() = %v, want %v", gotEq, test.wantEq)
 			}
 		})
 	}
 }
 
-func (s) TestNode_ToProto(t *testing.T) {
+func (s) TestNodeProto(t *testing.T) {
 	tests := []struct {
-		desc      string
-		inputNode Node
-		wantProto *v3corepb.Node
+		desc                string
+		inputNode           clients.Node
+		inputClientFeatures []string
+		wantProto           *v3corepb.Node
 	}{
 		{
 			desc: "all_fields_set",
-			inputNode: Node{
+			inputNode: clients.Node{
 				ID:      "id",
 				Cluster: "cluster",
-				Locality: Locality{
+				Locality: clients.Locality{
 					Region:  "region",
 					Zone:    "zone",
 					SubZone: "sub_zone",
@@ -299,8 +296,8 @@ func (s) TestNode_ToProto(t *testing.T) {
 				Metadata:         newStructProtoFromMap(t, map[string]any{"k1": "v1", "k2": 101, "k3": 280.0}),
 				UserAgentName:    "user agent",
 				UserAgentVersion: "version",
-				clientFeatures:   []string{"feature1", "feature2"},
 			},
+			inputClientFeatures: []string{"feature1", "feature2"},
 			wantProto: &v3corepb.Node{
 				Id:      "id",
 				Cluster: "cluster",
@@ -317,7 +314,7 @@ func (s) TestNode_ToProto(t *testing.T) {
 		},
 		{
 			desc: "some_fields_unset",
-			inputNode: Node{
+			inputNode: clients.Node{
 				ID: "id",
 			},
 			wantProto: &v3corepb.Node{
@@ -329,9 +326,9 @@ func (s) TestNode_ToProto(t *testing.T) {
 		},
 		{
 			desc: "empty_locality",
-			inputNode: Node{
+			inputNode: clients.Node{
 				ID:       "id",
-				Locality: Locality{},
+				Locality: clients.Locality{},
 			},
 			wantProto: &v3corepb.Node{
 				Id:                   "id",
@@ -344,7 +341,7 @@ func (s) TestNode_ToProto(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			gotProto := test.inputNode.toProto()
+			gotProto := NodeProto(test.inputNode, test.inputClientFeatures)
 			if diff := cmp.Diff(test.wantProto, gotProto, protocmp.Transform()); diff != "" {
 				t.Fatalf("Unexpected diff in node proto: (-want, +got):\n%s", diff)
 			}

--- a/xds/internal/clients/internal/pretty/pretty.go
+++ b/xds/internal/clients/internal/pretty/pretty.go
@@ -1,0 +1,73 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package pretty defines helper functions to pretty-print structs for logging.
+package pretty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/protoadapt"
+)
+
+const jsonIndent = "  "
+
+// ToJSON marshals the input into a json string.
+//
+// If marshal fails, it falls back to fmt.Sprintf("%+v").
+func ToJSON(e any) string {
+	if ee, ok := e.(protoadapt.MessageV1); ok {
+		e = protoadapt.MessageV2Of(ee)
+	}
+
+	if ee, ok := e.(protoadapt.MessageV2); ok {
+		mm := protojson.MarshalOptions{
+			Indent:    jsonIndent,
+			Multiline: true,
+		}
+		ret, err := mm.Marshal(ee)
+		if err != nil {
+			// This may fail for proto.Anys, e.g. for xDS v2, LDS, the v2
+			// messages are not imported, and this will fail because the message
+			// is not found.
+			return fmt.Sprintf("%+v", ee)
+		}
+		return string(ret)
+	}
+
+	ret, err := json.MarshalIndent(e, "", jsonIndent)
+	if err != nil {
+		return fmt.Sprintf("%+v", e)
+	}
+	return string(ret)
+}
+
+// FormatJSON formats the input json bytes with indentation.
+//
+// If Indent fails, it returns the unchanged input as string.
+func FormatJSON(b []byte) string {
+	var out bytes.Buffer
+	err := json.Indent(&out, b, "", jsonIndent)
+	if err != nil {
+		return string(b)
+	}
+	return out.String()
+}

--- a/xds/internal/clients/internal/testutils/channel.go
+++ b/xds/internal/clients/internal/testutils/channel.go
@@ -1,0 +1,120 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package testutils contains testing helpers for xDS and LRS clients.
+package testutils
+
+import (
+	"context"
+)
+
+// DefaultChanBufferSize is the default buffer size of the underlying channel.
+const DefaultChanBufferSize = 1
+
+// Channel wraps a generic channel and provides a timed receive operation.
+type Channel struct {
+	// C is the underlying channel on which values sent using the SendXxx()
+	// methods are delivered. Tests which cannot use ReceiveXxx() for whatever
+	// reasons can use C to read the values.
+	C chan any
+}
+
+// Send sends value on the underlying channel.
+func (c *Channel) Send(value any) {
+	c.C <- value
+}
+
+// SendContext sends value on the underlying channel, or returns an error if
+// the context expires.
+func (c *Channel) SendContext(ctx context.Context, value any) error {
+	select {
+	case c.C <- value:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// SendOrFail attempts to send value on the underlying channel.  Returns true
+// if successful or false if the channel was full.
+func (c *Channel) SendOrFail(value any) bool {
+	select {
+	case c.C <- value:
+		return true
+	default:
+		return false
+	}
+}
+
+// ReceiveOrFail returns the value on the underlying channel and true, or nil
+// and false if the channel was empty.
+func (c *Channel) ReceiveOrFail() (any, bool) {
+	select {
+	case got := <-c.C:
+		return got, true
+	default:
+		return nil, false
+	}
+}
+
+// Drain drains the channel by repeatedly reading from it until it is empty.
+func (c *Channel) Drain() {
+	for {
+		select {
+		case <-c.C:
+		default:
+			return
+		}
+	}
+}
+
+// Receive returns the value received on the underlying channel, or the error
+// returned by ctx if it is closed or cancelled.
+func (c *Channel) Receive(ctx context.Context) (any, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case got := <-c.C:
+		return got, nil
+	}
+}
+
+// Replace clears the value on the underlying channel, and sends the new value.
+//
+// It's expected to be used with a size-1 channel, to only keep the most
+// up-to-date item. This method is inherently racy when invoked concurrently
+// from multiple goroutines.
+func (c *Channel) Replace(value any) {
+	for {
+		select {
+		case c.C <- value:
+			return
+		case <-c.C:
+		}
+	}
+}
+
+// NewChannel returns a new Channel.
+func NewChannel() *Channel {
+	return NewChannelWithSize(DefaultChanBufferSize)
+}
+
+// NewChannelWithSize returns a new Channel with a buffer of bufSize.
+func NewChannelWithSize(bufSize int) *Channel {
+	return &Channel{C: make(chan any, bufSize)}
+}

--- a/xds/internal/clients/internal/testutils/e2e/clientresources.go
+++ b/xds/internal/clients/internal/testutils/e2e/clientresources.go
@@ -1,0 +1,892 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package e2e
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3aggregateclusterpb "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/aggregate/v3"
+	v3routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	v3typepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+)
+
+const (
+	// ServerListenerResourceNameTemplate is the Listener resource name template
+	// used on the server side.
+	ServerListenerResourceNameTemplate = "grpc/server?xds.resource.listening_address=%s"
+	// ClientSideCertProviderInstance is the certificate provider instance name
+	// used in the Cluster resource on the client side.
+	ClientSideCertProviderInstance = "client-side-certificate-provider-instance"
+	// ServerSideCertProviderInstance is the certificate provider instance name
+	// used in the Listener resource on the server side.
+	ServerSideCertProviderInstance = "server-side-certificate-provider-instance"
+)
+
+// SecurityLevel allows the test to control the security level to be used in the
+// resource returned by this package.
+type SecurityLevel int
+
+const (
+	// SecurityLevelNone is used when no security configuration is required.
+	SecurityLevelNone SecurityLevel = iota
+	// SecurityLevelTLS is used when security configuration corresponding to TLS
+	// is required. Only the server presents an identity certificate in this
+	// configuration.
+	SecurityLevelTLS
+	// SecurityLevelMTLS is used when security configuration corresponding to
+	// mTLS is required. Both client and server present identity certificates in
+	// this configuration.
+	SecurityLevelMTLS
+	// SecurityLevelTLSWithSystemRootCerts is used when security configuration
+	// corresponding to TLS is required. Only the server presents an identity
+	// certificate in this configuration and the client uses system root certs
+	// to validate the server certificate.
+	SecurityLevelTLSWithSystemRootCerts
+)
+
+// ResourceParams wraps the arguments to be passed to DefaultClientResources.
+type ResourceParams struct {
+	// DialTarget is the client's dial target. This is used as the name of the
+	// Listener resource.
+	DialTarget string
+	// NodeID is the id of the xdsClient to which this update is to be pushed.
+	NodeID string
+	// Host is the host of the default Endpoint resource.
+	Host string
+	// port is the port of the default Endpoint resource.
+	Port uint32
+	// SecLevel controls the security configuration in the Cluster resource.
+	SecLevel SecurityLevel
+}
+
+// DefaultClientResources returns a set of resources (LDS, RDS, CDS, EDS) for a
+// client to generically connect to one server.
+func DefaultClientResources(params ResourceParams) UpdateOptions {
+	routeConfigName := "route-" + params.DialTarget
+	clusterName := "cluster-" + params.DialTarget
+	endpointsName := "endpoints-" + params.DialTarget
+	return UpdateOptions{
+		NodeID:    params.NodeID,
+		Listeners: []*v3listenerpb.Listener{DefaultClientListener(params.DialTarget, routeConfigName)},
+		Routes:    []*v3routepb.RouteConfiguration{DefaultRouteConfig(routeConfigName, params.DialTarget, clusterName)},
+		Clusters:  []*v3clusterpb.Cluster{DefaultCluster(clusterName, endpointsName, params.SecLevel)},
+		Endpoints: []*v3endpointpb.ClusterLoadAssignment{DefaultEndpoint(endpointsName, params.Host, []uint32{params.Port})},
+	}
+}
+
+// RouterHTTPFilter is the HTTP Filter configuration for the Router filter.
+var RouterHTTPFilter = HTTPFilter("router", &v3routerpb.Router{})
+
+// DefaultClientListener returns a basic xds Listener resource to be used on
+// the client side.
+func DefaultClientListener(target, routeName string) *v3listenerpb.Listener {
+	hcm := marshalAny(&v3httppb.HttpConnectionManager{
+		RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{Rds: &v3httppb.Rds{
+			ConfigSource: &v3corepb.ConfigSource{
+				ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+			},
+			RouteConfigName: routeName,
+		}},
+		HttpFilters: []*v3httppb.HttpFilter{HTTPFilter("router", &v3routerpb.Router{})}, // router fields are unused by grpc
+	})
+	return &v3listenerpb.Listener{
+		Name:        target,
+		ApiListener: &v3listenerpb.ApiListener{ApiListener: hcm},
+		FilterChains: []*v3listenerpb.FilterChain{{
+			Name: "filter-chain-name",
+			Filters: []*v3listenerpb.Filter{{
+				Name:       wellknown.HTTPConnectionManager,
+				ConfigType: &v3listenerpb.Filter_TypedConfig{TypedConfig: hcm},
+			}},
+		}},
+	}
+}
+
+func marshalAny(m proto.Message) *anypb.Any {
+	a, err := anypb.New(m)
+	if err != nil {
+		panic(fmt.Sprintf("anypb.New(%+v) failed: %v", m, err))
+	}
+	return a
+}
+
+// filterChainWontMatch returns a filter chain that won't match if running the
+// test locally.
+func filterChainWontMatch(routeName string, addressPrefix string, srcPorts []uint32) *v3listenerpb.FilterChain {
+	hcm := &v3httppb.HttpConnectionManager{
+		RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+			Rds: &v3httppb.Rds{
+				ConfigSource: &v3corepb.ConfigSource{
+					ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+				},
+				RouteConfigName: routeName,
+			},
+		},
+		HttpFilters: []*v3httppb.HttpFilter{RouterHTTPFilter},
+	}
+	return &v3listenerpb.FilterChain{
+		Name: routeName + "-wont-match",
+		FilterChainMatch: &v3listenerpb.FilterChainMatch{
+			PrefixRanges: []*v3corepb.CidrRange{
+				{
+					AddressPrefix: addressPrefix,
+					PrefixLen: &wrapperspb.UInt32Value{
+						Value: uint32(0),
+					},
+				},
+			},
+			SourceType:  v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+			SourcePorts: srcPorts,
+			SourcePrefixRanges: []*v3corepb.CidrRange{
+				{
+					AddressPrefix: addressPrefix,
+					PrefixLen: &wrapperspb.UInt32Value{
+						Value: uint32(0),
+					},
+				},
+			},
+		},
+		Filters: []*v3listenerpb.Filter{
+			{
+				Name:       "filter-1",
+				ConfigType: &v3listenerpb.Filter_TypedConfig{TypedConfig: marshalAny(hcm)},
+			},
+		},
+	}
+}
+
+// ListenerResourceThreeRouteResources returns a listener resource that points
+// to three route configurations. Only the filter chain that points to the first
+// route config can be matched to.
+func ListenerResourceThreeRouteResources(host string, port uint32, secLevel SecurityLevel, routeName string) *v3listenerpb.Listener {
+	lis := defaultServerListenerCommon(host, port, secLevel, routeName, false)
+	lis.FilterChains = append(lis.FilterChains, filterChainWontMatch("routeName2", "1.1.1.1", []uint32{1}))
+	lis.FilterChains = append(lis.FilterChains, filterChainWontMatch("routeName3", "2.2.2.2", []uint32{2}))
+	return lis
+}
+
+// ListenerResourceFallbackToDefault returns a listener resource that contains a
+// filter chain that will never get chosen to process traffic and a default
+// filter chain. The default filter chain points to routeName2.
+func ListenerResourceFallbackToDefault(host string, port uint32, secLevel SecurityLevel) *v3listenerpb.Listener {
+	lis := defaultServerListenerCommon(host, port, secLevel, "", false)
+	lis.FilterChains = nil
+	lis.FilterChains = append(lis.FilterChains, filterChainWontMatch("routeName", "1.1.1.1", []uint32{1}))
+	lis.DefaultFilterChain = filterChainWontMatch("routeName2", "2.2.2.2", []uint32{2})
+	return lis
+}
+
+// DefaultServerListener returns a basic xds Listener resource to be used on the
+// server side. The returned Listener resource contains an inline route
+// configuration with the name of routeName.
+func DefaultServerListener(host string, port uint32, secLevel SecurityLevel, routeName string) *v3listenerpb.Listener {
+	return defaultServerListenerCommon(host, port, secLevel, routeName, true)
+}
+
+func defaultServerListenerCommon(host string, port uint32, secLevel SecurityLevel, routeName string, inlineRouteConfig bool) *v3listenerpb.Listener {
+	var hcm *v3httppb.HttpConnectionManager
+	if inlineRouteConfig {
+		hcm = &v3httppb.HttpConnectionManager{
+			RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+				RouteConfig: &v3routepb.RouteConfiguration{
+					Name: routeName,
+					VirtualHosts: []*v3routepb.VirtualHost{{
+						// This "*" string matches on any incoming authority. This is to ensure any
+						// incoming RPC matches to Route_NonForwardingAction and will proceed as
+						// normal.
+						Domains: []string{"*"},
+						Routes: []*v3routepb.Route{{
+							Match: &v3routepb.RouteMatch{
+								PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+							},
+							Action: &v3routepb.Route_NonForwardingAction{},
+						}}}}},
+			},
+			HttpFilters: []*v3httppb.HttpFilter{RouterHTTPFilter},
+		}
+	} else {
+		hcm = &v3httppb.HttpConnectionManager{
+			RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{
+				Rds: &v3httppb.Rds{
+					ConfigSource: &v3corepb.ConfigSource{
+						ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+					},
+					RouteConfigName: routeName,
+				},
+			},
+			HttpFilters: []*v3httppb.HttpFilter{RouterHTTPFilter},
+		}
+	}
+
+	var tlsContext *v3tlspb.DownstreamTlsContext
+	switch secLevel {
+	case SecurityLevelNone:
+	case SecurityLevelTLS:
+		tlsContext = &v3tlspb.DownstreamTlsContext{
+			CommonTlsContext: &v3tlspb.CommonTlsContext{
+				TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+					InstanceName: ServerSideCertProviderInstance,
+				},
+			},
+		}
+	case SecurityLevelMTLS:
+		tlsContext = &v3tlspb.DownstreamTlsContext{
+			RequireClientCertificate: &wrapperspb.BoolValue{Value: true},
+			CommonTlsContext: &v3tlspb.CommonTlsContext{
+				TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+					InstanceName: ServerSideCertProviderInstance,
+				},
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance{
+					ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+						InstanceName: ServerSideCertProviderInstance,
+					},
+				},
+			},
+		}
+	}
+
+	var ts *v3corepb.TransportSocket
+	if tlsContext != nil {
+		ts = &v3corepb.TransportSocket{
+			Name: "envoy.transport_sockets.tls",
+			ConfigType: &v3corepb.TransportSocket_TypedConfig{
+				TypedConfig: marshalAny(tlsContext),
+			},
+		}
+	}
+	return &v3listenerpb.Listener{
+		Name: fmt.Sprintf(ServerListenerResourceNameTemplate, net.JoinHostPort(host, strconv.Itoa(int(port)))),
+		Address: &v3corepb.Address{
+			Address: &v3corepb.Address_SocketAddress{
+				SocketAddress: &v3corepb.SocketAddress{
+					Address: host,
+					PortSpecifier: &v3corepb.SocketAddress_PortValue{
+						PortValue: port,
+					},
+				},
+			},
+		},
+		FilterChains: []*v3listenerpb.FilterChain{
+			{
+				Name: "v4-wildcard",
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges: []*v3corepb.CidrRange{
+						{
+							AddressPrefix: "0.0.0.0",
+							PrefixLen: &wrapperspb.UInt32Value{
+								Value: uint32(0),
+							},
+						},
+					},
+					SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+					SourcePrefixRanges: []*v3corepb.CidrRange{
+						{
+							AddressPrefix: "0.0.0.0",
+							PrefixLen: &wrapperspb.UInt32Value{
+								Value: uint32(0),
+							},
+						},
+					},
+				},
+				Filters: []*v3listenerpb.Filter{
+					{
+						Name:       "filter-1",
+						ConfigType: &v3listenerpb.Filter_TypedConfig{TypedConfig: marshalAny(hcm)},
+					},
+				},
+				TransportSocket: ts,
+			},
+			{
+				Name: "v6-wildcard",
+				FilterChainMatch: &v3listenerpb.FilterChainMatch{
+					PrefixRanges: []*v3corepb.CidrRange{
+						{
+							AddressPrefix: "::",
+							PrefixLen: &wrapperspb.UInt32Value{
+								Value: uint32(0),
+							},
+						},
+					},
+					SourceType: v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK,
+					SourcePrefixRanges: []*v3corepb.CidrRange{
+						{
+							AddressPrefix: "::",
+							PrefixLen: &wrapperspb.UInt32Value{
+								Value: uint32(0),
+							},
+						},
+					},
+				},
+				Filters: []*v3listenerpb.Filter{
+					{
+						Name:       "filter-1",
+						ConfigType: &v3listenerpb.Filter_TypedConfig{TypedConfig: marshalAny(hcm)},
+					},
+				},
+				TransportSocket: ts,
+			},
+		},
+	}
+}
+
+// HTTPFilter constructs an xds HttpFilter with the provided name and config.
+func HTTPFilter(name string, config proto.Message) *v3httppb.HttpFilter {
+	return &v3httppb.HttpFilter{
+		Name: name,
+		ConfigType: &v3httppb.HttpFilter_TypedConfig{
+			TypedConfig: marshalAny(config),
+		},
+	}
+}
+
+// DefaultRouteConfig returns a basic xds RouteConfig resource.
+func DefaultRouteConfig(routeName, vhDomain, clusterName string) *v3routepb.RouteConfiguration {
+	return &v3routepb.RouteConfiguration{
+		Name: routeName,
+		VirtualHosts: []*v3routepb.VirtualHost{{
+			Domains: []string{vhDomain},
+			Routes: []*v3routepb.Route{{
+				Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
+				Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+					ClusterSpecifier: &v3routepb.RouteAction_WeightedClusters{WeightedClusters: &v3routepb.WeightedCluster{
+						Clusters: []*v3routepb.WeightedCluster_ClusterWeight{
+							{
+								Name:   clusterName,
+								Weight: &wrapperspb.UInt32Value{Value: 100},
+							},
+						},
+					}},
+				}},
+			}},
+		}},
+	}
+}
+
+// RouteConfigClusterSpecifierType determines the cluster specifier type for the
+// route actions configured in the returned RouteConfiguration resource.
+type RouteConfigClusterSpecifierType int
+
+const (
+	// RouteConfigClusterSpecifierTypeCluster results in the cluster specifier
+	// being set to a RouteAction_Cluster.
+	RouteConfigClusterSpecifierTypeCluster RouteConfigClusterSpecifierType = iota
+	// RouteConfigClusterSpecifierTypeWeightedCluster results in the cluster
+	// specifier being set to RouteAction_WeightedClusters.
+	RouteConfigClusterSpecifierTypeWeightedCluster
+	// RouteConfigClusterSpecifierTypeClusterSpecifierPlugin results in the
+	// cluster specifier being set to a RouteAction_ClusterSpecifierPlugin.
+	RouteConfigClusterSpecifierTypeClusterSpecifierPlugin
+)
+
+// RouteConfigOptions contains options to configure a RouteConfiguration
+// resource.
+type RouteConfigOptions struct {
+	// RouteConfigName is the name of the RouteConfiguration resource.
+	RouteConfigName string
+	// ListenerName is the name of the Listener resource which uses this
+	// RouteConfiguration.
+	ListenerName string
+	// ClusterSpecifierType determines the cluster specifier type.
+	ClusterSpecifierType RouteConfigClusterSpecifierType
+	// ClusterName is name of the cluster resource used when the cluster
+	// specifier type is set to RouteConfigClusterSpecifierTypeCluster.
+	//
+	// Default value of "A" is used if left unspecified.
+	ClusterName string
+	// WeightedClusters is a map from cluster name to weights, and is used when
+	// the cluster specifier type is set to
+	// RouteConfigClusterSpecifierTypeWeightedCluster.
+	//
+	// Default value of {"A": 75, "B": 25} is used if left unspecified.
+	WeightedClusters map[string]int
+	// The below two fields specify the name of the cluster specifier plugin and
+	// its configuration, and are used when the cluster specifier type is set to
+	// RouteConfigClusterSpecifierTypeClusterSpecifierPlugin. Tests are expected
+	// to provide valid values for these fields when appropriate.
+	ClusterSpecifierPluginName   string
+	ClusterSpecifierPluginConfig *anypb.Any
+}
+
+// RouteConfigResourceWithOptions returns a RouteConfiguration resource
+// configured with the provided options.
+func RouteConfigResourceWithOptions(opts RouteConfigOptions) *v3routepb.RouteConfiguration {
+	switch opts.ClusterSpecifierType {
+	case RouteConfigClusterSpecifierTypeCluster:
+		clusterName := opts.ClusterName
+		if clusterName == "" {
+			clusterName = "A"
+		}
+		return &v3routepb.RouteConfiguration{
+			Name: opts.RouteConfigName,
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{opts.ListenerName},
+				Routes: []*v3routepb.Route{{
+					Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
+					Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+						ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterName},
+					}},
+				}},
+			}},
+		}
+	case RouteConfigClusterSpecifierTypeWeightedCluster:
+		weightedClusters := opts.WeightedClusters
+		if weightedClusters == nil {
+			weightedClusters = map[string]int{"A": 75, "B": 25}
+		}
+		clusters := []*v3routepb.WeightedCluster_ClusterWeight{}
+		for name, weight := range weightedClusters {
+			clusters = append(clusters, &v3routepb.WeightedCluster_ClusterWeight{
+				Name:   name,
+				Weight: &wrapperspb.UInt32Value{Value: uint32(weight)},
+			})
+		}
+		return &v3routepb.RouteConfiguration{
+			Name: opts.RouteConfigName,
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{opts.ListenerName},
+				Routes: []*v3routepb.Route{{
+					Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
+					Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+						ClusterSpecifier: &v3routepb.RouteAction_WeightedClusters{WeightedClusters: &v3routepb.WeightedCluster{Clusters: clusters}},
+					}},
+				}},
+			}},
+		}
+	case RouteConfigClusterSpecifierTypeClusterSpecifierPlugin:
+		return &v3routepb.RouteConfiguration{
+			Name: opts.RouteConfigName,
+			ClusterSpecifierPlugins: []*v3routepb.ClusterSpecifierPlugin{{
+				Extension: &v3corepb.TypedExtensionConfig{
+					Name:        opts.ClusterSpecifierPluginName,
+					TypedConfig: opts.ClusterSpecifierPluginConfig,
+				}},
+			},
+			VirtualHosts: []*v3routepb.VirtualHost{{
+				Domains: []string{opts.ListenerName},
+				Routes: []*v3routepb.Route{{
+					Match: &v3routepb.RouteMatch{PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"}},
+					Action: &v3routepb.Route_Route{Route: &v3routepb.RouteAction{
+						ClusterSpecifier: &v3routepb.RouteAction_ClusterSpecifierPlugin{ClusterSpecifierPlugin: opts.ClusterSpecifierPluginName},
+					}},
+				}},
+			}},
+		}
+	default:
+		panic(fmt.Sprintf("unsupported cluster specifier plugin type: %v", opts.ClusterSpecifierType))
+	}
+}
+
+// DefaultCluster returns a basic xds Cluster resource.
+func DefaultCluster(clusterName, edsServiceName string, secLevel SecurityLevel) *v3clusterpb.Cluster {
+	return ClusterResourceWithOptions(ClusterOptions{
+		ClusterName:   clusterName,
+		ServiceName:   edsServiceName,
+		Policy:        LoadBalancingPolicyRoundRobin,
+		SecurityLevel: secLevel,
+	})
+}
+
+// LoadBalancingPolicy determines the policy used for balancing load across
+// endpoints in the Cluster.
+type LoadBalancingPolicy int
+
+const (
+	// LoadBalancingPolicyRoundRobin results in the use of the weighted_target
+	// LB policy to balance load across localities and endpoints in the cluster.
+	LoadBalancingPolicyRoundRobin LoadBalancingPolicy = iota
+	// LoadBalancingPolicyRingHash results in the use of the ring_hash LB policy
+	// as the leaf policy.
+	LoadBalancingPolicyRingHash
+)
+
+// ClusterType specifies the type of the Cluster resource.
+type ClusterType int
+
+const (
+	// ClusterTypeEDS specifies a Cluster that uses EDS to resolve endpoints.
+	ClusterTypeEDS ClusterType = iota
+	// ClusterTypeLogicalDNS specifies a Cluster that uses DNS to resolve
+	// endpoints.
+	ClusterTypeLogicalDNS
+	// ClusterTypeAggregate specifies a Cluster that is made up of child
+	// clusters.
+	ClusterTypeAggregate
+)
+
+// ClusterOptions contains options to configure a Cluster resource.
+type ClusterOptions struct {
+	Type ClusterType
+	// ClusterName is the name of the Cluster resource.
+	ClusterName string
+	// ServiceName is the EDS service name of the Cluster. Applicable only when
+	// cluster type is EDS.
+	ServiceName string
+	// ChildNames is the list of child Cluster names. Applicable only when
+	// cluster type is Aggregate.
+	ChildNames []string
+	// DNSHostName is the dns host name of the Cluster. Applicable only when the
+	// cluster type is DNS.
+	DNSHostName string
+	// DNSPort is the port number of the Cluster. Applicable only when the
+	// cluster type is DNS.
+	DNSPort uint32
+	// Policy is the LB policy to be used.
+	Policy LoadBalancingPolicy
+	// SecurityLevel determines the security configuration for the Cluster.
+	SecurityLevel SecurityLevel
+	// EnableLRS adds a load reporting configuration with a config source
+	// pointing to self.
+	EnableLRS bool
+}
+
+// ClusterResourceWithOptions returns an xDS Cluster resource configured with
+// the provided options.
+func ClusterResourceWithOptions(opts ClusterOptions) *v3clusterpb.Cluster {
+	var tlsContext *v3tlspb.UpstreamTlsContext
+	switch opts.SecurityLevel {
+	case SecurityLevelNone:
+	case SecurityLevelTLS:
+		tlsContext = &v3tlspb.UpstreamTlsContext{
+			CommonTlsContext: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance{
+					ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+						InstanceName: ClientSideCertProviderInstance,
+					},
+				},
+			},
+		}
+	case SecurityLevelMTLS:
+		tlsContext = &v3tlspb.UpstreamTlsContext{
+			CommonTlsContext: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance{
+					ValidationContextCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+						InstanceName: ClientSideCertProviderInstance,
+					},
+				},
+				TlsCertificateCertificateProviderInstance: &v3tlspb.CommonTlsContext_CertificateProviderInstance{
+					InstanceName: ClientSideCertProviderInstance,
+				},
+			},
+		}
+	case SecurityLevelTLSWithSystemRootCerts:
+		tlsContext = &v3tlspb.UpstreamTlsContext{
+			CommonTlsContext: &v3tlspb.CommonTlsContext{
+				ValidationContextType: &v3tlspb.CommonTlsContext_ValidationContext{
+					ValidationContext: &v3tlspb.CertificateValidationContext{
+						SystemRootCerts: &v3tlspb.CertificateValidationContext_SystemRootCerts{},
+					},
+				},
+			},
+		}
+	}
+
+	var lbPolicy v3clusterpb.Cluster_LbPolicy
+	switch opts.Policy {
+	case LoadBalancingPolicyRoundRobin:
+		lbPolicy = v3clusterpb.Cluster_ROUND_ROBIN
+	case LoadBalancingPolicyRingHash:
+		lbPolicy = v3clusterpb.Cluster_RING_HASH
+	}
+	cluster := &v3clusterpb.Cluster{
+		Name:     opts.ClusterName,
+		LbPolicy: lbPolicy,
+	}
+	switch opts.Type {
+	case ClusterTypeEDS:
+		cluster.ClusterDiscoveryType = &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_EDS}
+		cluster.EdsClusterConfig = &v3clusterpb.Cluster_EdsClusterConfig{
+			EdsConfig: &v3corepb.ConfigSource{
+				ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{
+					Ads: &v3corepb.AggregatedConfigSource{},
+				},
+			},
+			ServiceName: opts.ServiceName,
+		}
+	case ClusterTypeLogicalDNS:
+		cluster.ClusterDiscoveryType = &v3clusterpb.Cluster_Type{Type: v3clusterpb.Cluster_LOGICAL_DNS}
+		cluster.LoadAssignment = &v3endpointpb.ClusterLoadAssignment{
+			Endpoints: []*v3endpointpb.LocalityLbEndpoints{{
+				LbEndpoints: []*v3endpointpb.LbEndpoint{{
+					HostIdentifier: &v3endpointpb.LbEndpoint_Endpoint{
+						Endpoint: &v3endpointpb.Endpoint{
+							Address: &v3corepb.Address{
+								Address: &v3corepb.Address_SocketAddress{
+									SocketAddress: &v3corepb.SocketAddress{
+										Address: opts.DNSHostName,
+										PortSpecifier: &v3corepb.SocketAddress_PortValue{
+											PortValue: opts.DNSPort,
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+			}},
+		}
+	case ClusterTypeAggregate:
+		cluster.ClusterDiscoveryType = &v3clusterpb.Cluster_ClusterType{
+			ClusterType: &v3clusterpb.Cluster_CustomClusterType{
+				Name: "envoy.clusters.aggregate",
+				TypedConfig: marshalAny(&v3aggregateclusterpb.ClusterConfig{
+					Clusters: opts.ChildNames,
+				}),
+			},
+		}
+	}
+	if tlsContext != nil {
+		cluster.TransportSocket = &v3corepb.TransportSocket{
+			Name: "envoy.transport_sockets.tls",
+			ConfigType: &v3corepb.TransportSocket_TypedConfig{
+				TypedConfig: marshalAny(tlsContext),
+			},
+		}
+	}
+	if opts.EnableLRS {
+		cluster.LrsServer = &v3corepb.ConfigSource{
+			ConfigSourceSpecifier: &v3corepb.ConfigSource_Self{
+				Self: &v3corepb.SelfConfigSource{},
+			},
+		}
+	}
+	return cluster
+}
+
+// LocalityID represents a locality identifier.
+type LocalityID struct {
+	Region  string
+	Zone    string
+	SubZone string
+}
+
+// LocalityOptions contains options to configure a Locality.
+type LocalityOptions struct {
+	// Name is the unique locality name.
+	Name string
+	// Weight is the weight of the locality, used for load balancing.
+	Weight uint32
+	// Backends is a set of backends belonging to this locality.
+	Backends []BackendOptions
+	// Priority is the priority of the locality. Defaults to 0.
+	Priority uint32
+	// Locality is the locality identifier. If not specified, a random
+	// identifier is generated.
+	Locality LocalityID
+}
+
+// BackendOptions contains options to configure individual backends in a
+// locality.
+type BackendOptions struct {
+	// Ports on which the backend is accepting connections. All backends
+	// are expected to run on localhost, hence host name is not stored here.
+	Ports []uint32
+	// Health status of the backend. Default is UNKNOWN which is treated the
+	// same as HEALTHY.
+	HealthStatus v3corepb.HealthStatus
+	// Weight sets the backend weight. Defaults to 1.
+	Weight uint32
+}
+
+// EndpointOptions contains options to configure an Endpoint (or
+// ClusterLoadAssignment) resource.
+type EndpointOptions struct {
+	// ClusterName is the name of the Cluster resource (or EDS service name)
+	// containing the endpoints specified below.
+	ClusterName string
+	// Host is the hostname of the endpoints. In our e2e tests, hostname must
+	// always be "localhost".
+	Host string
+	// Localities is a set of localities belonging to this resource.
+	Localities []LocalityOptions
+	// DropPercents is a map from drop category to a drop percentage. If unset,
+	// no drops are configured.
+	DropPercents map[string]int
+}
+
+// DefaultEndpoint returns a basic xds Endpoint resource.
+func DefaultEndpoint(clusterName string, host string, ports []uint32) *v3endpointpb.ClusterLoadAssignment {
+	var bOpts []BackendOptions
+	for _, p := range ports {
+		bOpts = append(bOpts, BackendOptions{Ports: []uint32{p}, Weight: 1})
+	}
+	return EndpointResourceWithOptions(EndpointOptions{
+		ClusterName: clusterName,
+		Host:        host,
+		Localities: []LocalityOptions{
+			{
+				Backends: bOpts,
+				Weight:   1,
+			},
+		},
+	})
+}
+
+// EndpointResourceWithOptions returns an xds Endpoint resource configured with
+// the provided options.
+func EndpointResourceWithOptions(opts EndpointOptions) *v3endpointpb.ClusterLoadAssignment {
+	var endpoints []*v3endpointpb.LocalityLbEndpoints
+	for i, locality := range opts.Localities {
+		var lbEndpoints []*v3endpointpb.LbEndpoint
+		for _, b := range locality.Backends {
+			// Weight defaults to 1.
+			if b.Weight == 0 {
+				b.Weight = 1
+			}
+			additionalAddresses := make([]*v3endpointpb.Endpoint_AdditionalAddress, len(b.Ports)-1)
+			for i, p := range b.Ports[1:] {
+				additionalAddresses[i] = &v3endpointpb.Endpoint_AdditionalAddress{
+					Address: &v3corepb.Address{Address: &v3corepb.Address_SocketAddress{
+						SocketAddress: &v3corepb.SocketAddress{
+							Protocol:      v3corepb.SocketAddress_TCP,
+							Address:       opts.Host,
+							PortSpecifier: &v3corepb.SocketAddress_PortValue{PortValue: p},
+						}},
+					},
+				}
+			}
+			lbEndpoints = append(lbEndpoints, &v3endpointpb.LbEndpoint{
+				HostIdentifier: &v3endpointpb.LbEndpoint_Endpoint{Endpoint: &v3endpointpb.Endpoint{
+					Address: &v3corepb.Address{Address: &v3corepb.Address_SocketAddress{
+						SocketAddress: &v3corepb.SocketAddress{
+							Protocol:      v3corepb.SocketAddress_TCP,
+							Address:       opts.Host,
+							PortSpecifier: &v3corepb.SocketAddress_PortValue{PortValue: b.Ports[0]},
+						},
+					}},
+					AdditionalAddresses: additionalAddresses,
+				}},
+				HealthStatus:        b.HealthStatus,
+				LoadBalancingWeight: &wrapperspb.UInt32Value{Value: b.Weight},
+			})
+		}
+
+		l := locality.Locality
+		if l == (LocalityID{}) {
+			l = LocalityID{
+				Region:  fmt.Sprintf("region-%d", i+1),
+				Zone:    fmt.Sprintf("zone-%d", i+1),
+				SubZone: fmt.Sprintf("subzone-%d", i+1),
+			}
+		}
+		endpoints = append(endpoints, &v3endpointpb.LocalityLbEndpoints{
+			Locality:            &v3corepb.Locality{Region: l.Region, Zone: l.Zone, SubZone: l.SubZone},
+			LbEndpoints:         lbEndpoints,
+			LoadBalancingWeight: &wrapperspb.UInt32Value{Value: locality.Weight},
+			Priority:            locality.Priority,
+		})
+	}
+
+	cla := &v3endpointpb.ClusterLoadAssignment{
+		ClusterName: opts.ClusterName,
+		Endpoints:   endpoints,
+	}
+
+	var drops []*v3endpointpb.ClusterLoadAssignment_Policy_DropOverload
+	for category, val := range opts.DropPercents {
+		drops = append(drops, &v3endpointpb.ClusterLoadAssignment_Policy_DropOverload{
+			Category: category,
+			DropPercentage: &v3typepb.FractionalPercent{
+				Numerator:   uint32(val),
+				Denominator: v3typepb.FractionalPercent_HUNDRED,
+			},
+		})
+	}
+	if len(drops) != 0 {
+		cla.Policy = &v3endpointpb.ClusterLoadAssignment_Policy{
+			DropOverloads: drops,
+		}
+	}
+	return cla
+}
+
+// DefaultServerListenerWithRouteConfigName returns a basic xds Listener
+// resource to be used on the server side. The returned Listener resource
+// contains a RouteConfiguration resource name that needs to be resolved.
+func DefaultServerListenerWithRouteConfigName(host string, port uint32, secLevel SecurityLevel, routeName string) *v3listenerpb.Listener {
+	return defaultServerListenerCommon(host, port, secLevel, routeName, false)
+}
+
+// RouteConfigNoRouteMatch returns an xDS RouteConfig resource which a route
+// with no route match. This will be NACKed by the xDS Client.
+func RouteConfigNoRouteMatch(routeName string) *v3routepb.RouteConfiguration {
+	return &v3routepb.RouteConfiguration{
+		Name: routeName,
+		VirtualHosts: []*v3routepb.VirtualHost{{
+			// This "*" string matches on any incoming authority. This is to ensure any
+			// incoming RPC matches to Route_NonForwardingAction and will proceed as
+			// normal.
+			Domains: []string{"*"},
+			Routes: []*v3routepb.Route{{
+				Action: &v3routepb.Route_NonForwardingAction{},
+			}}}}}
+}
+
+// RouteConfigNonForwardingAction returns an xDS RouteConfig resource which
+// specifies to route to a route specifying non forwarding action. This is
+// intended to be used on the server side for RDS requests, and corresponds to
+// the inline route configuration in DefaultServerListener.
+func RouteConfigNonForwardingAction(routeName string) *v3routepb.RouteConfiguration {
+	return &v3routepb.RouteConfiguration{
+		Name: routeName,
+		VirtualHosts: []*v3routepb.VirtualHost{{
+			// This "*" string matches on any incoming authority. This is to ensure any
+			// incoming RPC matches to Route_NonForwardingAction and will proceed as
+			// normal.
+			Domains: []string{"*"},
+			Routes: []*v3routepb.Route{{
+				Match: &v3routepb.RouteMatch{
+					PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+				},
+				Action: &v3routepb.Route_NonForwardingAction{},
+			}}}}}
+}
+
+// RouteConfigFilterAction returns an xDS RouteConfig resource which specifies
+// to route to a route specifying route filter action. Since this is not type
+// non forwarding action, this should fail requests that match to this server
+// side.
+func RouteConfigFilterAction(routeName string) *v3routepb.RouteConfiguration {
+	return &v3routepb.RouteConfiguration{
+		Name: routeName,
+		VirtualHosts: []*v3routepb.VirtualHost{{
+			// This "*" string matches on any incoming authority. This is to
+			// ensure any incoming RPC matches to Route_Route and will fail with
+			// UNAVAILABLE.
+			Domains: []string{"*"},
+			Routes: []*v3routepb.Route{{
+				Match: &v3routepb.RouteMatch{
+					PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+				},
+				Action: &v3routepb.Route_FilterAction{},
+			}}}}}
+}

--- a/xds/internal/clients/internal/testutils/e2e/logging.go
+++ b/xds/internal/clients/internal/testutils/e2e/logging.go
@@ -1,0 +1,40 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package e2e
+
+// serverLogger implements the Logger interface defined at
+// envoyproxy/go-control-plane/pkg/log. This is passed to the Snapshot cache.
+type serverLogger struct {
+	logger interface {
+		Logf(format string, args ...any)
+	}
+}
+
+func (l serverLogger) Debugf(format string, args ...any) {
+	l.logger.Logf(format, args...)
+}
+func (l serverLogger) Infof(format string, args ...any) {
+	l.logger.Logf(format, args...)
+}
+func (l serverLogger) Warnf(format string, args ...any) {
+	l.logger.Logf(format, args...)
+}
+func (l serverLogger) Errorf(format string, args ...any) {
+	l.logger.Logf(format, args...)
+}

--- a/xds/internal/clients/internal/testutils/e2e/server.go
+++ b/xds/internal/clients/internal/testutils/e2e/server.go
@@ -1,0 +1,257 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package e2e provides utilities for end2end testing of xDS and LRS clients
+// functionalities.
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/xds/internal/clients/internal/testutils/fakeserver"
+
+	v3clusterpb "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3endpointpb "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+	v3cache "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	v3resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	v3server "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+)
+
+// ManagementServer is a thin wrapper around the xDS control plane
+// implementation provided by envoyproxy/go-control-plane.
+type ManagementServer struct {
+	// Address is the host:port on which the management server is listening for
+	// new connections.
+	Address string
+
+	// LRSServer points to the fake LRS server implementation. Set only if the
+	// SupportLoadReportingService option was set to true when creating this
+	// management server.
+	LRSServer *fakeserver.Server
+
+	cancel  context.CancelFunc    // To stop the v3 ADS service.
+	xs      v3server.Server       // v3 implementation of ADS.
+	gs      *grpc.Server          // gRPC server which exports the ADS service.
+	cache   v3cache.SnapshotCache // Resource snapshot.
+	version int                   // Version of resource snapshot.
+
+	// A logging interface, usually supplied from *testing.T.
+	logger interface {
+		Logf(format string, args ...any)
+	}
+}
+
+// ManagementServerOptions contains options to be passed to the management
+// server during creation.
+type ManagementServerOptions struct {
+	// Listener to accept connections on. If nil, a TPC listener on a local port
+	// will be created and used.
+	Listener net.Listener
+
+	// SupportLoadReportingService, if set, results in the load reporting
+	// service being registered on the same port as that of ADS.
+	SupportLoadReportingService bool
+
+	// AllowResourceSubSet allows the management server to respond to requests
+	// before all configured resources are explicitly named in the request. The
+	// default behavior that we want is for the management server to wait for
+	// all configured resources to be requested before responding to any of
+	// them, since this is how we have run our tests historically, and should be
+	// set to true only for tests which explicitly require the other behavior.
+	AllowResourceSubset bool
+
+	// ServerFeaturesIgnoreResourceDeletion, if set, results in a bootstrap config
+	// where the server features list contains `ignore_resource_deletion`. This
+	// results in gRPC ignoring resource deletions from the management server, as
+	// per A53.
+	ServerFeaturesIgnoreResourceDeletion bool
+
+	// The callbacks defined below correspond to the state of the world (sotw)
+	// version of the xDS API on the management server.
+
+	// OnStreamOpen is called when an xDS stream is opened. The callback is
+	// invoked with the assigned stream ID and the type URL from the incoming
+	// request (or "" for ADS).
+	//
+	// Returning an error from this callback will end processing and close the
+	// stream. OnStreamClosed will still be called.
+	OnStreamOpen func(context.Context, int64, string) error
+
+	// OnStreamClosed is called immediately prior to closing an xDS stream. The
+	// callback is invoked with the stream ID of the stream being closed.
+	OnStreamClosed func(int64, *v3corepb.Node)
+
+	// OnStreamRequest is called when a request is received on the stream. The
+	// callback is invoked with the stream ID of the stream on which the request
+	// was received and the received request.
+	//
+	// Returning an error from this callback will end processing and close the
+	// stream. OnStreamClosed will still be called.
+	OnStreamRequest func(int64, *v3discoverypb.DiscoveryRequest) error
+
+	// OnStreamResponse is called immediately prior to sending a response on the
+	// stream. The callback is invoked with the stream ID of the stream on which
+	// the response is being sent along with the incoming request and the outgoing
+	// response.
+	OnStreamResponse func(context.Context, int64, *v3discoverypb.DiscoveryRequest, *v3discoverypb.DiscoveryResponse)
+}
+
+// StartManagementServer initializes a management server which implements the
+// AggregatedDiscoveryService endpoint. The management server is initialized
+// with no resources. Tests should call the Update() method to change the
+// resource snapshot held by the management server, as per by the test logic.
+//
+// Registers a cleanup function on t to stop the management server.
+func StartManagementServer(t *testing.T, opts ManagementServerOptions) *ManagementServer {
+	t.Helper()
+
+	// Create a snapshot cache. The first parameter to NewSnapshotCache()
+	// controls whether the server should wait for all resources to be
+	// explicitly named in the request before responding to any of them.
+	wait := !opts.AllowResourceSubset
+	cache := v3cache.NewSnapshotCache(wait, v3cache.IDHash{}, serverLogger{t})
+	t.Logf("Created new snapshot cache...")
+
+	lis := opts.Listener
+	if lis == nil {
+		var err error
+		lis, err = net.Listen("tcp", "localhost:0")
+		if err != nil {
+			t.Fatalf("Failed to listen on localhost:0: %v", err)
+		}
+	}
+
+	// Cancelling the context passed to the server is the only way of stopping it
+	// at the end of the test.
+	ctx, cancel := context.WithCancel(context.Background())
+	callbacks := v3server.CallbackFuncs{
+		StreamOpenFunc:     opts.OnStreamOpen,
+		StreamClosedFunc:   opts.OnStreamClosed,
+		StreamRequestFunc:  opts.OnStreamRequest,
+		StreamResponseFunc: opts.OnStreamResponse,
+	}
+
+	// Create an xDS management server and register the ADS implementation
+	// provided by it on a gRPC server.
+	xs := v3server.NewServer(ctx, cache, callbacks)
+	gs := grpc.NewServer()
+	v3discoverygrpc.RegisterAggregatedDiscoveryServiceServer(gs, xs)
+	t.Logf("Registered Aggregated Discovery Service (ADS)...")
+
+	mgmtServer := &ManagementServer{
+		Address: lis.Addr().String(),
+		cancel:  cancel,
+		version: 0,
+		gs:      gs,
+		xs:      xs,
+		cache:   cache,
+		logger:  t,
+	}
+	if opts.SupportLoadReportingService {
+		lrs := fakeserver.NewServer(lis.Addr().String())
+		v3lrsgrpc.RegisterLoadReportingServiceServer(gs, lrs)
+		mgmtServer.LRSServer = lrs
+		t.Logf("Registered Load Reporting Service (LRS)...")
+	}
+
+	// Start serving.
+	go gs.Serve(lis)
+	t.Logf("xDS management server serving at: %v...", lis.Addr().String())
+	t.Cleanup(mgmtServer.Stop)
+	return mgmtServer
+}
+
+// UpdateOptions wraps parameters to be passed to the Update() method.
+type UpdateOptions struct {
+	// NodeID is the id of the client to which this update is to be pushed.
+	NodeID string
+	// Endpoints, Clusters, Routes, and Listeners are the updated list of xds
+	// resources for the server.  All must be provided with each Update.
+	Endpoints []*v3endpointpb.ClusterLoadAssignment
+	Clusters  []*v3clusterpb.Cluster
+	Routes    []*v3routepb.RouteConfiguration
+	Listeners []*v3listenerpb.Listener
+	// SkipValidation indicates whether we want to skip validation (by not
+	// calling snapshot.Consistent()). It can be useful for negative tests,
+	// where we send updates that the client will NACK.
+	SkipValidation bool
+}
+
+// Update changes the resource snapshot held by the management server, which
+// updates connected clients as required.
+func (s *ManagementServer) Update(ctx context.Context, opts UpdateOptions) error {
+	s.version++
+
+	// Create a snapshot with the passed in resources.
+	resources := map[v3resource.Type][]types.Resource{
+		v3resource.ListenerType: resourceSlice(opts.Listeners),
+		v3resource.RouteType:    resourceSlice(opts.Routes),
+		v3resource.ClusterType:  resourceSlice(opts.Clusters),
+		v3resource.EndpointType: resourceSlice(opts.Endpoints),
+	}
+	snapshot, err := v3cache.NewSnapshot(strconv.Itoa(s.version), resources)
+	if err != nil {
+		return fmt.Errorf("failed to create new snapshot cache: %v", err)
+
+	}
+	if !opts.SkipValidation {
+		if err := snapshot.Consistent(); err != nil {
+			return fmt.Errorf("failed to create new resource snapshot: %v", err)
+		}
+	}
+	s.logger.Logf("Created new resource snapshot...")
+
+	// Update the cache with the new resource snapshot.
+	if err := s.cache.SetSnapshot(ctx, opts.NodeID, snapshot); err != nil {
+		return fmt.Errorf("failed to update resource snapshot in management server: %v", err)
+	}
+	s.logger.Logf("Updated snapshot cache with resource snapshot...")
+	return nil
+}
+
+// Stop stops the management server.
+func (s *ManagementServer) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.gs.Stop()
+}
+
+// resourceSlice accepts a slice of any type of proto messages and returns a
+// slice of types.Resource.  Will panic if there is an input type mismatch.
+func resourceSlice(i any) []types.Resource {
+	v := reflect.ValueOf(i)
+	rs := make([]types.Resource, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		rs[i] = v.Index(i).Interface().(types.Resource)
+	}
+	return rs
+}

--- a/xds/internal/clients/internal/testutils/fakeserver/server.go
+++ b/xds/internal/clients/internal/testutils/fakeserver/server.go
@@ -1,0 +1,254 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package fakeserver provides a fake implementation of the management server.
+//
+// This package is recommended only for scenarios which cannot be tested using
+// the xDS management server (which uses envoy-go-control-plane) provided by the
+// `internal/testutils/e2e` package.
+package fakeserver
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/xds/internal/clients/internal/testutils"
+	"google.golang.org/protobuf/proto"
+
+	v3discoverygrpc "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	v3lrsgrpc "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+	v3lrspb "github.com/envoyproxy/go-control-plane/envoy/service/load_stats/v3"
+)
+
+const (
+	// TODO: Make this a var or a field in the server if there is a need to use a
+	// value other than this default.
+	defaultChannelBufferSize = 50
+	defaultDialTimeout       = 5 * time.Second
+)
+
+// Request wraps the request protobuf (xds/LRS) and error received by the
+// Server in a call to stream.Recv().
+type Request struct {
+	Req proto.Message
+	Err error
+}
+
+// Response wraps the response protobuf (xds/LRS) and error that the Server
+// should send out to the client through a call to stream.Send()
+type Response struct {
+	Resp proto.Message
+	Err  error
+}
+
+// Server is a fake implementation of xDS and LRS protocols. It listens on the
+// same port for both services and exposes a bunch of channels to send/receive
+// messages.
+//
+// This server is recommended only for scenarios which cannot be tested using
+// the xDS management server (which uses envoy-go-control-plane) provided by the
+// `internal/testutils/xds/e2e` package.
+type Server struct {
+	// XDSRequestChan is a channel on which received xDS requests are made
+	// available to the users of this Server.
+	XDSRequestChan *testutils.Channel
+	// XDSResponseChan is a channel on which the Server accepts xDS responses
+	// to be sent to the client.
+	XDSResponseChan chan *Response
+	// LRSRequestChan is a channel on which received LRS requests are made
+	// available to the users of this Server.
+	LRSRequestChan *testutils.Channel
+	// LRSResponseChan is a channel on which the Server accepts the LRS
+	// response to be sent to the client.
+	LRSResponseChan chan *Response
+	// LRSStreamOpenChan is a channel on which the Server sends notifications
+	// when a new LRS stream is created.
+	LRSStreamOpenChan *testutils.Channel
+	// LRSStreamCloseChan is a channel on which the Server sends notifications
+	// when an existing LRS stream is closed.
+	LRSStreamCloseChan *testutils.Channel
+	// NewConnChan is a channel on which the fake server notifies receipt of new
+	// connection attempts. Tests can gate on this event before proceeding to
+	// other actions which depend on a connection to the fake server being up.
+	NewConnChan *testutils.Channel
+	// Address is the host:port on which the Server is listening for requests.
+	Address string
+
+	// The underlying fake implementation of xDS and LRS.
+	*xdsServerV3
+	*lrsServerV3
+}
+
+type wrappedListener struct {
+	net.Listener
+	server *Server
+}
+
+func (wl *wrappedListener) Accept() (net.Conn, error) {
+	c, err := wl.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	wl.server.NewConnChan.Send(struct{}{})
+	return c, err
+}
+
+// StartServer makes a new Server and gets it to start listening on the given
+// net.Listener. If the given net.Listener is nil, a new one is created on a
+// local port for gRPC requests. The returned cancel function should be invoked
+// by the caller upon completion of the test.
+func StartServer(lis net.Listener) (*Server, func(), error) {
+	if lis == nil {
+		var err error
+		lis, err = net.Listen("tcp", "localhost:0")
+		if err != nil {
+			return nil, func() {}, fmt.Errorf("net.Listen() failed: %v", err)
+		}
+	}
+
+	s := NewServer(lis.Addr().String())
+	wp := &wrappedListener{
+		Listener: lis,
+		server:   s,
+	}
+
+	server := grpc.NewServer()
+	v3lrsgrpc.RegisterLoadReportingServiceServer(server, s)
+	v3discoverygrpc.RegisterAggregatedDiscoveryServiceServer(server, s)
+	go server.Serve(wp)
+
+	return s, func() { server.Stop() }, nil
+}
+
+// NewServer returns a new instance of Server, set to accept requests on addr.
+// It is the responsibility of the caller to register the exported ADS and LRS
+// services on an appropriate gRPC server. Most usages should prefer
+// StartServer() instead of this.
+func NewServer(addr string) *Server {
+	s := &Server{
+		XDSRequestChan:     testutils.NewChannelWithSize(defaultChannelBufferSize),
+		LRSRequestChan:     testutils.NewChannelWithSize(defaultChannelBufferSize),
+		NewConnChan:        testutils.NewChannelWithSize(defaultChannelBufferSize),
+		XDSResponseChan:    make(chan *Response, defaultChannelBufferSize),
+		LRSResponseChan:    make(chan *Response, 1), // The server only ever sends one response.
+		LRSStreamOpenChan:  testutils.NewChannelWithSize(defaultChannelBufferSize),
+		LRSStreamCloseChan: testutils.NewChannelWithSize(defaultChannelBufferSize),
+		Address:            addr,
+	}
+	s.xdsServerV3 = &xdsServerV3{reqChan: s.XDSRequestChan, respChan: s.XDSResponseChan}
+	s.lrsServerV3 = &lrsServerV3{reqChan: s.LRSRequestChan, respChan: s.LRSResponseChan, streamOpenChan: s.LRSStreamOpenChan, streamCloseChan: s.LRSStreamCloseChan}
+	return s
+}
+
+type xdsServerV3 struct {
+	reqChan  *testutils.Channel
+	respChan chan *Response
+}
+
+func (xdsS *xdsServerV3) StreamAggregatedResources(s v3discoverygrpc.AggregatedDiscoveryService_StreamAggregatedResourcesServer) error {
+	errCh := make(chan error, 2)
+	go func() {
+		for {
+			req, err := s.Recv()
+			if err != nil {
+				errCh <- err
+				return
+			}
+			xdsS.reqChan.Send(&Request{req, err})
+		}
+	}()
+	go func() {
+		var retErr error
+		defer func() {
+			errCh <- retErr
+		}()
+
+		for {
+			select {
+			case r := <-xdsS.respChan:
+				if r.Err != nil {
+					retErr = r.Err
+					return
+				}
+				if err := s.Send(r.Resp.(*v3discoverypb.DiscoveryResponse)); err != nil {
+					retErr = err
+					return
+				}
+			case <-s.Context().Done():
+				retErr = s.Context().Err()
+				return
+			}
+		}
+	}()
+
+	if err := <-errCh; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (xdsS *xdsServerV3) DeltaAggregatedResources(v3discoverygrpc.AggregatedDiscoveryService_DeltaAggregatedResourcesServer) error {
+	return status.Error(codes.Unimplemented, "")
+}
+
+type lrsServerV3 struct {
+	reqChan         *testutils.Channel
+	respChan        chan *Response
+	streamOpenChan  *testutils.Channel
+	streamCloseChan *testutils.Channel
+}
+
+func (lrsS *lrsServerV3) StreamLoadStats(s v3lrsgrpc.LoadReportingService_StreamLoadStatsServer) error {
+	lrsS.streamOpenChan.Send(nil)
+	defer lrsS.streamCloseChan.Send(nil)
+
+	req, err := s.Recv()
+	lrsS.reqChan.Send(&Request{req, err})
+	if err != nil {
+		return err
+	}
+
+	select {
+	case r := <-lrsS.respChan:
+		if r.Err != nil {
+			return r.Err
+		}
+		if err := s.Send(r.Resp.(*v3lrspb.LoadStatsResponse)); err != nil {
+			return err
+		}
+	case <-s.Context().Done():
+		return s.Context().Err()
+	}
+
+	for {
+		req, err := s.Recv()
+		lrsS.reqChan.Send(&Request{req, err})
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+	}
+}

--- a/xds/internal/clients/lrsclient/load_store.go
+++ b/xds/internal/clients/lrsclient/load_store.go
@@ -1,0 +1,78 @@
+//revive:disable:unused-parameter
+
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package lrsclient
+
+// A LoadStore aggregates loads for multiple clusters and services that are
+// intended to be reported via LRS.
+//
+// LoadStore stores loads reported to a single LRS server. Use multiple stores
+// for multiple servers.
+//
+// It is safe for concurrent use.
+type LoadStore struct {
+}
+
+// Stop stops the LRS stream associated with this LoadStore.
+//
+// If this LoadStore is the only one using the underlying LRS stream, the
+// stream will be closed. If other LoadStores are also using the same stream,
+// the reference count to the stream is decremented, and the stream remains
+// open until all LoadStores have called Stop().
+//
+// If the stream is being closed, this method attempts to flush any remaining
+// load data to the LRS server within the specified ReportLoadTimeout in the
+// client's Config. If the data cannot be written within the timeout, the
+// stream is canceled without flushing the data.
+func (ls *LoadStore) Stop() error {
+	panic("unimplemented")
+}
+
+// ReporterForCluster returns the PerClusterReporter for the given cluster and
+// service.
+func (ls *LoadStore) ReporterForCluster(clusterName, serviceName string) PerClusterReporter {
+	panic("unimplemented")
+}
+
+// PerClusterReporter records load data pertaining to a single cluster. It
+// provides methods to record call starts, finishes, server-reported loads,
+// and dropped calls.
+type PerClusterReporter struct {
+}
+
+// CallStarted records a call started in the LoadStore.
+func (p *PerClusterReporter) CallStarted(locality string) {
+	panic("unimplemented")
+}
+
+// CallFinished records a call finished in the LoadStore.
+func (p *PerClusterReporter) CallFinished(locality string, err error) {
+	panic("unimplemented")
+}
+
+// CallServerLoad records the server load in the LoadStore.
+func (p *PerClusterReporter) CallServerLoad(locality, name string, val float64) {
+	panic("unimplemented")
+}
+
+// CallDropped records a call dropped in the LoadStore.
+func (p *PerClusterReporter) CallDropped(category string) {
+	panic("unimplemented")
+}

--- a/xds/internal/clients/lrsclient/lrsclient.go
+++ b/xds/internal/clients/lrsclient/lrsclient.go
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package lrsclient provides an LRS (Load Reporting Service) client.
+//
+// See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/load_stats/v3/lrs.proto
+package lrsclient
+
+import "google.golang.org/grpc/xds/internal/clients"
+
+// LRSClient is an LRS (Load Reporting Service) client.
+type LRSClient struct {
+}
+
+// New returns a new LRS Client configured with the provided config.
+func New(_ Config) (*LRSClient, error) {
+	panic("unimplemented")
+}
+
+// ReportLoad creates a new load reporting stream for the provided server. It
+// creates and returns a LoadStore for the caller to report loads.
+func (*LRSClient) ReportLoad(_ clients.ServerIdentifier) *LoadStore {
+	panic("unimplemented")
+}

--- a/xds/internal/clients/lrsclient/lrsconfig.go
+++ b/xds/internal/clients/lrsclient/lrsconfig.go
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package lrsclient
+
+import (
+	"time"
+
+	"google.golang.org/grpc/xds/internal/clients"
+)
+
+// Config is used to configure an LRS client. After one has been passed to the
+// LRS client's New function, no part of it may modified. A Config may be
+// reused; the lrsclient package will also not modify it.
+type Config struct {
+	// Node is the identity of the client application reporting load to the
+	// LRS server.
+	Node clients.Node
+
+	// TransportBuilder is used to connect to the LRS server.
+	TransportBuilder clients.TransportBuilder
+
+	// ReportLoadTimeout is the timeout used when reporting load to the LRS
+	// server.
+	ReportLoadTimeout time.Duration
+}

--- a/xds/internal/clients/transport_builder.go
+++ b/xds/internal/clients/transport_builder.go
@@ -23,19 +23,19 @@ import (
 )
 
 // TransportBuilder provides the functionality to create a communication
-// channel to an xDS management server.
+// channel to an xDS or LRS server.
 type TransportBuilder interface {
-	// Build creates a new [Transport] instance to the xDS server based on the
-	// provided ServerConfig.
-	Build(ServerConfig ServerConfig) (Transport, error)
+	// Build creates a new Transport instance to the server based on the
+	// provided ServerIdentifier.
+	Build(serverIdentifier ServerIdentifier) (Transport, error)
 }
 
-// Transport provides the functionality to communicate with an xDS server using
-// streaming calls.
+// Transport provides the functionality to communicate with an xDS or LRS
+// server using streaming calls.
 type Transport interface {
-	// NewStream creates a new streaming call to the xDS server for the
-	// specified RPC method name. The returned Stream interface can be used
-	// to send and receive messages on the stream.
+	// NewStream creates a new streaming call to the server for the specific
+	// RPC method name. The returned Stream interface can be used to send and
+	// receive messages on the stream.
 	NewStream(context.Context, string) (Stream, error)
 
 	// Close closes the Transport.
@@ -43,7 +43,7 @@ type Transport interface {
 }
 
 // Stream provides methods to send and receive messages on a stream. Messages
-// are represented as a byte slice ([]byte).
+// are represented as a byte slice.
 type Stream interface {
 	// Send sends the provided message on the stream.
 	Send([]byte) error

--- a/xds/internal/clients/xdsclient/internal/ads/ads_stream.go
+++ b/xds/internal/clients/xdsclient/internal/ads/ads_stream.go
@@ -1,0 +1,839 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package ads provides the implementation of an ADS (Aggregated Discovery
+// Service) stream for the xDS client.
+package ads
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc/xds/internal/clients"
+	"google.golang.org/grpc/xds/internal/clients/clientslog"
+	"google.golang.org/grpc/xds/internal/clients/internal/backoff"
+	"google.golang.org/grpc/xds/internal/clients/internal/buffer"
+	iclientslog "google.golang.org/grpc/xds/internal/clients/internal/clientslog"
+	"google.golang.org/grpc/xds/internal/clients/internal/pretty"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/xdsresource"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+const (
+	// Any per-RPC level logs which print complete request or response messages
+	// should be gated at this verbosity level. Other per-RPC level logs which print
+	// terse output should be at `INFO` and verbosity 2.
+	perRPCVerbosityLevel = 9
+	// InvalidArgument indicates client specified an invalid argument.
+	// Note that this differs from FailedPrecondition. It indicates arguments
+	// that are problematic regardless of the state of the system
+	// (e.g., a malformed file name).
+	invalidArgumentErrCode = 3
+)
+
+// Response represents a response received on the ADS stream. It contains the
+// type URL, version, and resources for the response.
+type Response struct {
+	TypeURL   string
+	Version   string
+	Resources []*anypb.Any
+}
+
+// DataAndErrTuple is a struct that holds a resource and an error. It is used to
+// return a resource and any associated error from a function.
+type DataAndErrTuple struct {
+	Resource xdsclient.ResourceData
+	Err      error
+}
+
+// StreamEventHandler is an interface that defines the callbacks for events that
+// occur on the ADS stream. Methods on this interface may be invoked
+// concurrently and implementations need to handle them in a thread-safe manner.
+type StreamEventHandler interface {
+	OnADSStreamError(error)                           // Called when the ADS stream breaks.
+	OnADSWatchExpiry(xdsclient.ResourceType, string)  // Called when the watch timer expires for a resource.
+	OnADSResponse(Response, func()) ([]string, error) // Called when a response is received on the ADS stream.
+}
+
+// WatchState is a enum that describes the watch state of a particular
+// resource.
+type WatchState int
+
+const (
+	// ResourceWatchStateStarted is the state where a watch for a resource was
+	// started, but a request asking for that resource is yet to be sent to the
+	// management server.
+	ResourceWatchStateStarted WatchState = iota
+	// ResourceWatchStateRequested is the state when a request has been sent for
+	// the resource being watched.
+	ResourceWatchStateRequested
+	// ResourceWatchStateReceived is the state when a response has been received
+	// for the resource being watched.
+	ResourceWatchStateReceived
+	// ResourceWatchStateTimeout is the state when the watch timer associated
+	// with the resource expired because no response was received.
+	ResourceWatchStateTimeout
+)
+
+// ResourceWatchState is the state corresponding to a resource being watched.
+type ResourceWatchState struct {
+	State       WatchState  // Watch state of the resource.
+	ExpiryTimer *time.Timer // Timer for the expiry of the watch.
+}
+
+// State corresponding to a resource type.
+type resourceTypeState struct {
+	version             string                         // Last acked version. Should not be reset when the stream breaks.
+	nonce               string                         // Last received nonce. Should be reset when the stream breaks.
+	bufferedRequests    chan struct{}                  // Channel to buffer requests when writing is blocked.
+	subscribedResources map[string]*ResourceWatchState // Map of subscribed resource names to their state.
+	pendingWrite        bool                           // True if there is a pending write for this resource type.
+}
+
+// StreamImpl provides the functionality associated with an ADS (Aggregated
+// Discovery Service) stream on the client side. It manages the lifecycle of the
+// ADS stream, including creating the stream, sending requests, and handling
+// responses. It also handles flow control and retries for the stream.
+type StreamImpl struct {
+	// The following fields are initialized from arguments passed to the
+	// constructor and are read-only afterwards, and hence can be accessed
+	// without a mutex.
+	transport          clients.Transport       // Transport to use for ADS stream.
+	eventHandler       StreamEventHandler      // Callbacks into the xdsChannel.
+	backoff            func(int) time.Duration // Backoff for retries, after stream failures.
+	nodeProto          *v3corepb.Node          // Identifies the gRPC application.
+	watchExpiryTimeout time.Duration           // Resource watch expiry timeout
+	logger             *iclientslog.PrefixLogger
+
+	// The following fields are initialized in the constructor and are not
+	// written to afterwards, and hence can be accessed without a mutex.
+	streamCh     chan clients.Stream // New ADS streams are pushed here.
+	requestCh    *buffer.Unbounded   // Subscriptions and unsubscriptions are pushed here.
+	runnerDoneCh chan struct{}       // Notify completion of runner goroutine.
+	cancel       context.CancelFunc  // To cancel the context passed to the runner goroutine.
+
+	// Guards access to the below fields (and to the contents of the map).
+	mu                sync.Mutex
+	resourceTypeState map[xdsclient.ResourceType]*resourceTypeState // Map of resource types to their state.
+	fc                *adsFlowControl                               // Flow control for ADS stream.
+	firstRequest      bool                                          // False after the first request is sent out.
+}
+
+// StreamOpts contains the options for creating a new ADS Stream.
+type StreamOpts struct {
+	Transport          clients.Transport       // xDS transport to create the stream on.
+	EventHandler       StreamEventHandler      // Callbacks for stream events.
+	Backoff            func(int) time.Duration // Backoff for retries, after stream failures.
+	NodeProto          *v3corepb.Node          // Node proto to identify the gRPC application.
+	WatchExpiryTimeout time.Duration           // Resource watch expiry timeout.
+	LogPrefix          string                  // Prefix to be used for log messages.
+}
+
+// NewStreamImpl initializes a new StreamImpl instance using the given
+// parameters.  It also launches goroutines responsible for managing reads and
+// writes for messages of the underlying stream.
+func NewStreamImpl(opts StreamOpts) *StreamImpl {
+	s := &StreamImpl{
+		transport:          opts.Transport,
+		eventHandler:       opts.EventHandler,
+		backoff:            opts.Backoff,
+		nodeProto:          opts.NodeProto,
+		watchExpiryTimeout: opts.WatchExpiryTimeout,
+
+		streamCh:          make(chan clients.Stream, 1),
+		requestCh:         buffer.NewUnbounded(),
+		runnerDoneCh:      make(chan struct{}),
+		resourceTypeState: make(map[xdsclient.ResourceType]*resourceTypeState),
+	}
+
+	l := clientslog.Component("xds")
+	s.logger = iclientslog.NewPrefixLogger(l, opts.LogPrefix+fmt.Sprintf("[ads-stream %p] ", s))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	go s.runner(ctx)
+	return s
+}
+
+// Stop blocks until the stream is closed and all spawned goroutines exit.
+func (s *StreamImpl) Stop() {
+	s.cancel()
+	s.requestCh.Close()
+	<-s.runnerDoneCh
+	s.logger.Infof("Stopping ADS stream")
+}
+
+// Subscribe subscribes to the given resource. It is assumed that multiple
+// subscriptions for the same resource is deduped at the caller. A discovery
+// request is sent out on the underlying stream for the resource type when there
+// is sufficient flow control quota.
+func (s *StreamImpl) Subscribe(typ xdsclient.ResourceType, name string) {
+	if s.logger.V(2) {
+		s.logger.Infof("Subscribing to resource %q of type %q", name, typ.TypeName)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.resourceTypeState[typ]
+	if !ok {
+		// An entry in the type state map is created as part of the first
+		// subscription request for this type.
+		state = &resourceTypeState{
+			subscribedResources: make(map[string]*ResourceWatchState),
+			bufferedRequests:    make(chan struct{}, 1),
+		}
+		s.resourceTypeState[typ] = state
+	}
+
+	// Create state for the newly subscribed resource. The watch timer will
+	// be started when a request for this resource is actually sent out.
+	state.subscribedResources[name] = &ResourceWatchState{State: ResourceWatchStateStarted}
+	state.pendingWrite = true
+
+	// Send a request for the resource type with updated subscriptions.
+	s.requestCh.Put(typ)
+}
+
+// Unsubscribe cancels the subscription to the given resource. It is a no-op if
+// the given resource does not exist. The watch expiry timer associated with the
+// resource is stopped if one is active. A discovery request is sent out on the
+// stream for the resource type when there is sufficient flow control quota.
+func (s *StreamImpl) Unsubscribe(typ xdsclient.ResourceType, name string) {
+	if s.logger.V(2) {
+		s.logger.Infof("Unsubscribing to resource %q of type %q", name, typ.TypeName)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.resourceTypeState[typ]
+	if !ok {
+		return
+	}
+
+	rs, ok := state.subscribedResources[name]
+	if !ok {
+		return
+	}
+	if rs.ExpiryTimer != nil {
+		rs.ExpiryTimer.Stop()
+	}
+	delete(state.subscribedResources, name)
+	state.pendingWrite = true
+
+	// Send a request for the resource type with updated subscriptions.
+	s.requestCh.Put(typ)
+}
+
+// runner is a long-running goroutine that handles the lifecycle of the ADS
+// stream. It spwans another goroutine to handle writes of discovery request
+// messages on the stream. Whenever an existing stream fails, it performs
+// exponential backoff (if no messages were received on that stream) before
+// creating a new stream.
+func (s *StreamImpl) runner(ctx context.Context) {
+	defer close(s.runnerDoneCh)
+
+	go s.send(ctx)
+
+	runStreamWithBackoff := func() error {
+		stream, err := s.transport.NewStream(ctx, "/envoy.service.discovery.v3.AggregatedDiscoveryService/StreamAggregatedResources")
+		if err != nil {
+			s.logger.Warningf("Failed to create a new ADS streaming RPC: %v", err)
+			s.onError(err, false)
+			return nil
+		}
+		if s.logger.V(2) {
+			s.logger.Infof("ADS stream created")
+		}
+
+		s.mu.Lock()
+		// Flow control is a property of the underlying streaming RPC call and
+		// needs to be initialized everytime a new one is created.
+		s.fc = newADSFlowControl(s.logger)
+		s.firstRequest = true
+		s.mu.Unlock()
+
+		// Ensure that the most recently created stream is pushed on the
+		// channel for the `send` goroutine to consume.
+		select {
+		case <-s.streamCh:
+		default:
+		}
+		s.streamCh <- stream
+
+		// Backoff state is reset upon successful receipt of at least one
+		// message from the server.
+		if s.recv(ctx, stream) {
+			return backoff.ErrResetBackoff
+		}
+		return nil
+	}
+	backoff.RunF(ctx, runStreamWithBackoff, s.backoff)
+}
+
+// send is a long running goroutine that handles sending discovery requests for
+// two scenarios:
+// - a new subscription or unsubscription request is received
+// - a new stream is created after the previous one failed
+func (s *StreamImpl) send(ctx context.Context) {
+	// Stores the most recent stream instance received on streamCh.
+	var stream clients.Stream
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case stream = <-s.streamCh:
+			if err := s.sendExisting(stream); err != nil {
+				// Send failed, clear the current stream. Attempt to resend will
+				// only be made after a new stream is created.
+				stream = nil
+				continue
+			}
+		case req, ok := <-s.requestCh.Get():
+			if !ok {
+				return
+			}
+			s.requestCh.Load()
+
+			typ := req.(xdsclient.ResourceType)
+			if err := s.sendNew(stream, typ); err != nil {
+				stream = nil
+				continue
+			}
+		}
+	}
+}
+
+// sendNew attempts to send a discovery request based on a new subscription or
+// unsubscription. If there is no flow control quota, the request is buffered
+// and will be sent later. This method also starts the watch expiry timer for
+// resources that were sent in the request for the first time, i.e. their watch
+// state is `watchStateStarted`.
+func (s *StreamImpl) sendNew(stream clients.Stream, typ xdsclient.ResourceType) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// If there's no stream yet, skip the request. This request will be resent
+	// when a new stream is created. If no stream is created, the watcher will
+	// timeout (same as server not sending response back).
+	if stream == nil {
+		return nil
+	}
+
+	// If local processing of the most recently received response is not yet
+	// complete, i.e. fc.pending == true, queue this write and return early.
+	// This allows us to batch writes for requests which are generated as part
+	// of local processing of a received response.
+	state := s.resourceTypeState[typ]
+	if s.fc.pending.Load() {
+		select {
+		case state.bufferedRequests <- struct{}{}:
+		default:
+		}
+		return nil
+	}
+
+	return s.sendMessageIfWritePendingLocked(stream, typ, state)
+}
+
+// sendExisting sends out discovery requests for existing resources when
+// recovering from a broken stream.
+//
+// The stream argument is guaranteed to be non-nil.
+func (s *StreamImpl) sendExisting(stream clients.Stream) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for typ, state := range s.resourceTypeState {
+		// Reset only the nonces map when the stream restarts.
+		//
+		// xDS spec says the following. See section:
+		// https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#ack-nack-and-resource-type-instance-version
+		//
+		// Note that the version for a resource type is not a property of an
+		// individual xDS stream but rather a property of the resources
+		// themselves. If the stream becomes broken and the client creates a new
+		// stream, the client’s initial request on the new stream should
+		// indicate the most recent version seen by the client on the previous
+		// stream
+		state.nonce = ""
+
+		if len(state.subscribedResources) == 0 {
+			continue
+		}
+
+		state.pendingWrite = true
+		if err := s.sendMessageIfWritePendingLocked(stream, typ, state); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sendBuffered sends out discovery requests for resources that were buffered
+// when they were subscribed to, because local processing of the previously
+// received response was not yet complete.
+//
+// The stream argument is guaranteed to be non-nil.
+func (s *StreamImpl) sendBuffered(stream clients.Stream) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for typ, state := range s.resourceTypeState {
+		select {
+		case <-state.bufferedRequests:
+			if err := s.sendMessageIfWritePendingLocked(stream, typ, state); err != nil {
+				return err
+			}
+		default:
+			// No buffered request.
+			continue
+		}
+	}
+	return nil
+}
+
+// sendMessageIfWritePendingLocked attempts to sends a discovery request to the
+// server, if there is a pending write for the given resource type.
+//
+// If the request is successfully sent, the pending write field is cleared and
+// watch timers are started for the resources in the request.
+//
+// Caller needs to hold c.mu.
+func (s *StreamImpl) sendMessageIfWritePendingLocked(stream clients.Stream, typ xdsclient.ResourceType, state *resourceTypeState) error {
+	if !state.pendingWrite {
+		if s.logger.V(2) {
+			s.logger.Infof("Skipping sending request for type %q, because all subscribed resources were already sent", typ.TypeURL)
+		}
+		return nil
+	}
+
+	names := resourceNames(state.subscribedResources)
+	if err := s.sendMessageLocked(stream, names, typ.TypeURL, state.version, state.nonce, nil); err != nil {
+		return err
+	}
+	state.pendingWrite = false
+
+	// Drain the buffered requests channel because we just sent a request for this
+	// resource type.
+	select {
+	case <-state.bufferedRequests:
+	default:
+	}
+
+	s.startWatchTimersLocked(typ, names)
+	return nil
+}
+
+// sendMessageLocked sends a discovery request to the server, populating the
+// different fields of the message with the given parameters. Returns a non-nil
+// error if the request could not be sent.
+//
+// Caller needs to hold c.mu.
+func (s *StreamImpl) sendMessageLocked(stream clients.Stream, names []string, url, version, nonce string, nackErr error) error {
+	req := &v3discoverypb.DiscoveryRequest{
+		ResourceNames: names,
+		TypeUrl:       url,
+		VersionInfo:   version,
+		ResponseNonce: nonce,
+	}
+
+	// The xDS protocol only requires that we send the node proto in the first
+	// discovery request on every stream. Sending the node proto in every
+	// request wastes CPU resources on the client and the server.
+	if s.firstRequest {
+		req.Node = s.nodeProto
+	}
+
+	if nackErr != nil {
+		req.ErrorDetail = &statuspb.Status{
+			Code: int32(invalidArgumentErrCode), Message: nackErr.Error(),
+		}
+	}
+
+	msg, err := proto.Marshal(req)
+	if err != nil {
+		s.logger.Warningf("Failed to marshal DiscoveryRequest: %v", err)
+		return err
+	}
+	if err := stream.Send(msg); err != nil {
+		s.logger.Warningf("Sending ADS request for type %q, resources: %v, version: %q, nonce: %q failed: %v", url, names, version, nonce, err)
+		return err
+	}
+	s.firstRequest = false
+
+	if s.logger.V(perRPCVerbosityLevel) {
+		s.logger.Infof("ADS request sent: %v", pretty.ToJSON(req))
+	} else if s.logger.V(2) {
+		s.logger.Warningf("ADS request sent for type %q, resources: %v, version: %q, nonce: %q", url, names, version, nonce)
+	}
+	return nil
+}
+
+// recv is responsible for receiving messages from the ADS stream.
+//
+// It performs the following actions:
+//   - Waits for local flow control to be available before sending buffered
+//     requests, if any.
+//   - Receives a message from the ADS stream. If an error is encountered here,
+//     it is handled by the onError method which propagates the error to all
+//     watchers.
+//   - Invokes the event handler's OnADSResponse method to process the message.
+//   - Sends an ACK or NACK to the server based on the response.
+//
+// It returns a boolean indicating whether at least one message was received
+// from the server.
+func (s *StreamImpl) recv(ctx context.Context, stream clients.Stream) bool {
+	msgReceived := false
+	for {
+		// Wait for ADS stream level flow control to be available, and send out
+		// a request if anything was buffered while we were waiting for local
+		// processing of the previous response to complete.
+		if !s.fc.wait(ctx) {
+			if s.logger.V(2) {
+				s.logger.Infof("ADS stream context canceled")
+			}
+			return msgReceived
+		}
+		s.sendBuffered(stream)
+
+		resources, url, version, nonce, err := s.recvMessage(stream)
+		if err != nil {
+			s.onError(err, msgReceived)
+			s.logger.Warningf("ADS stream closed: %v", err)
+			return msgReceived
+		}
+		msgReceived = true
+
+		// Invoke the onResponse event handler to parse the incoming message and
+		// decide whether to send an ACK or NACK.
+		resp := Response{
+			Resources: resources,
+			TypeURL:   url,
+			Version:   version,
+		}
+		var resourceNames []string
+		var nackErr error
+		s.fc.setPending()
+		resourceNames, nackErr = s.eventHandler.OnADSResponse(resp, s.fc.onDone)
+		if xdsresource.ErrType(nackErr) == xdsresource.ErrorTypeResourceTypeUnsupported {
+			// Based on gRFC A27, a general guiding principle is that if the
+			// server sends something the client didn't actually subscribe to,
+			// then the client ignores it. Here, we have received a response
+			// with resources of a type that we don't know about.
+			//
+			// Sending a NACK doesn't really seem appropriate here, since we're
+			// not actually validating what the server sent and therefore don't
+			// know that it's invalid.  But we shouldn't ACK either, because we
+			// don't know that it is valid.
+			s.logger.Warningf("%v", nackErr)
+			continue
+		}
+
+		s.onRecv(stream, resourceNames, url, version, nonce, nackErr)
+	}
+}
+
+func (s *StreamImpl) recvMessage(stream clients.Stream) (resources []*anypb.Any, url, version, nonce string, err error) {
+	r, err := stream.Recv()
+	if err != nil {
+		return nil, "", "", "", err
+	}
+	var resp v3discoverypb.DiscoveryResponse
+	if err := proto.Unmarshal(r, &resp); err != nil {
+		s.logger.Infof("Failed to unmarshal response to DiscoveryResponse: %v", err)
+		return nil, "", "", "", fmt.Errorf("unexpected message type %T", r)
+	}
+	if s.logger.V(perRPCVerbosityLevel) {
+		s.logger.Infof("ADS response received: %v", pretty.ToJSON(&resp))
+	} else if s.logger.V(2) {
+		s.logger.Infof("ADS response received for type %q, version %q, nonce %q", resp.GetTypeUrl(), resp.GetVersionInfo(), resp.GetNonce())
+	}
+	return resp.GetResources(), resp.GetTypeUrl(), resp.GetVersionInfo(), resp.GetNonce(), nil
+}
+
+// onRecv is invoked when a response is received from the server. The arguments
+// passed to this method correspond to the most recently received response.
+//
+// It performs the following actions:
+//   - updates resource type specific state
+//   - updates resource specific state for resources in the response
+//   - sends an ACK or NACK to the server based on the response
+func (s *StreamImpl) onRecv(stream clients.Stream, names []string, url, version, nonce string, nackErr error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Lookup the resource type specific state based on the type URL.
+	var typ xdsclient.ResourceType
+	for t := range s.resourceTypeState {
+		if t.TypeURL == url {
+			typ = t
+			break
+		}
+	}
+	typeState, ok := s.resourceTypeState[typ]
+	if !ok {
+		s.logger.Warningf("ADS stream received a response for type %q, but no state exists for it", url)
+		return
+	}
+
+	// Update the resource type specific state. This includes:
+	//   - updating the nonce unconditionally
+	//   - updating the version only if the response is to be ACKed
+	previousVersion := typeState.version
+	typeState.nonce = nonce
+	if nackErr == nil {
+		typeState.version = version
+	}
+
+	// Update the resource specific state. For all resources received as
+	// part of this response that are in state `started` or `requested`,
+	// this includes:
+	//   - setting the watch state to watchstateReceived
+	//   - stopping the expiry timer, if one exists
+	for _, name := range names {
+		rs, ok := typeState.subscribedResources[name]
+		if !ok {
+			s.logger.Warningf("ADS stream received a response for resource %q, but no state exists for it", name)
+			continue
+		}
+		if ws := rs.State; ws == ResourceWatchStateStarted || ws == ResourceWatchStateRequested {
+			rs.State = ResourceWatchStateReceived
+			if rs.ExpiryTimer != nil {
+				rs.ExpiryTimer.Stop()
+				rs.ExpiryTimer = nil
+			}
+		}
+	}
+
+	// Send an ACK or NACK.
+	subscribedResourceNames := resourceNames(typeState.subscribedResources)
+	if nackErr != nil {
+		s.logger.Warningf("Sending NACK for resource type: %q, version: %q, nonce: %q, reason: %v", url, version, nonce, nackErr)
+		s.sendMessageLocked(stream, subscribedResourceNames, url, previousVersion, nonce, nackErr)
+		return
+	}
+
+	if s.logger.V(2) {
+		s.logger.Infof("Sending ACK for resource type: %q, version: %q, nonce: %q", url, version, nonce)
+	}
+	s.sendMessageLocked(stream, subscribedResourceNames, url, version, nonce, nil)
+}
+
+// onError is called when an error occurs on the ADS stream. It stops any
+// outstanding resource timers and resets the watch state to started for any
+// resources that were in the requested state. It also handles the case where
+// the ADS stream was closed after receiving a response, which is not
+// considered an error.
+func (s *StreamImpl) onError(err error, msgReceived bool) {
+	// For resources that been requested but not yet responded to by the
+	// management server, stop the resource timers and reset the watch state to
+	// watchStateStarted. This is because we don't want the expiry timer to be
+	// running when we don't have a stream open to the management server.
+	s.mu.Lock()
+	for _, state := range s.resourceTypeState {
+		for _, rs := range state.subscribedResources {
+			if rs.State != ResourceWatchStateRequested {
+				continue
+			}
+			if rs.ExpiryTimer != nil {
+				rs.ExpiryTimer.Stop()
+				rs.ExpiryTimer = nil
+			}
+			rs.State = ResourceWatchStateStarted
+		}
+	}
+	s.mu.Unlock()
+
+	// Note that we do not consider it an error if the ADS stream was closed
+	// after having received a response on the stream. This is because there
+	// are legitimate reasons why the server may need to close the stream during
+	// normal operations, such as needing to rebalance load or the underlying
+	// connection hitting its max connection age limit.
+	// (see [gRFC A9](https://github.com/grpc/proposal/blob/master/A9-server-side-conn-mgt.md)).
+	if msgReceived {
+		err = xdsresource.NewErrorf(xdsresource.ErrTypeStreamFailedAfterRecv, "%s", err.Error())
+	}
+
+	s.eventHandler.OnADSStreamError(err)
+}
+
+// startWatchTimersLocked starts the expiry timers for the given resource names
+// of the specified resource type.  For each resource name, if the resource
+// watch state is in the "started" state, it transitions the state to
+// "requested" and starts an expiry timer. When the timer expires, the resource
+// watch state is set to "timeout" and the event handler callback is called.
+//
+// The caller must hold the s.mu lock.
+func (s *StreamImpl) startWatchTimersLocked(typ xdsclient.ResourceType, names []string) {
+	typeState := s.resourceTypeState[typ]
+	for _, name := range names {
+		resourceState, ok := typeState.subscribedResources[name]
+		if !ok {
+			continue
+		}
+		if resourceState.State != ResourceWatchStateStarted {
+			continue
+		}
+		resourceState.State = ResourceWatchStateRequested
+
+		rs := resourceState
+		resourceState.ExpiryTimer = time.AfterFunc(s.watchExpiryTimeout, func() {
+			s.mu.Lock()
+			rs.State = ResourceWatchStateTimeout
+			rs.ExpiryTimer = nil
+			s.mu.Unlock()
+			s.eventHandler.OnADSWatchExpiry(typ, name)
+		})
+	}
+}
+
+func resourceNames(m map[string]*ResourceWatchState) []string {
+	ret := make([]string, len(m))
+	idx := 0
+	for name := range m {
+		ret[idx] = name
+		idx++
+	}
+	return ret
+}
+
+// TriggerResourceNotFoundForTesting triggers a resource not found event for the
+// given resource type and name.  This is intended for testing purposes only, to
+// simulate a resource not found scenario.
+func (s *StreamImpl) TriggerResourceNotFoundForTesting(typ xdsclient.ResourceType, resourceName string) {
+	s.mu.Lock()
+
+	state, ok := s.resourceTypeState[typ]
+	if !ok {
+		s.mu.Unlock()
+		return
+	}
+	resourceState, ok := state.subscribedResources[resourceName]
+	if !ok {
+		s.mu.Unlock()
+		return
+	}
+
+	if s.logger.V(2) {
+		s.logger.Infof("Triggering resource not found for type: %s, resource name: %s", typ.TypeName, resourceName)
+	}
+	resourceState.State = ResourceWatchStateTimeout
+	if resourceState.ExpiryTimer != nil {
+		resourceState.ExpiryTimer.Stop()
+		resourceState.ExpiryTimer = nil
+	}
+	s.mu.Unlock()
+	go s.eventHandler.OnADSWatchExpiry(typ, resourceName)
+}
+
+// ResourceWatchStateForTesting returns the ResourceWatchState for the given
+// resource type and name.  This is intended for testing purposes only, to
+// inspect the internal state of the ADS stream.
+func (s *StreamImpl) ResourceWatchStateForTesting(typ xdsclient.ResourceType, resourceName string) (ResourceWatchState, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state, ok := s.resourceTypeState[typ]
+	if !ok {
+		return ResourceWatchState{}, fmt.Errorf("unknown resource type: %v", typ)
+	}
+	resourceState, ok := state.subscribedResources[resourceName]
+	if !ok {
+		return ResourceWatchState{}, fmt.Errorf("unknown resource name: %v", resourceName)
+	}
+	return *resourceState, nil
+}
+
+// adsFlowControl implements ADS stream level flow control that enables the
+// transport to block the reading of the next message off of the stream until
+// the previous update is consumed by all watchers.
+//
+// The lifetime of the flow control is tied to the lifetime of the stream.
+type adsFlowControl struct {
+	logger *iclientslog.PrefixLogger
+
+	// Whether the most recent update is pending consumption by all watchers.
+	pending atomic.Bool
+	// Channel used to notify when all the watchers have consumed the most
+	// recent update. Wait() blocks on reading a value from this channel.
+	readyCh chan struct{}
+}
+
+// newADSFlowControl returns a new adsFlowControl.
+func newADSFlowControl(logger *iclientslog.PrefixLogger) *adsFlowControl {
+	return &adsFlowControl{
+		logger:  logger,
+		readyCh: make(chan struct{}, 1),
+	}
+}
+
+// setPending changes the internal state to indicate that there is an update
+// pending consumption by all watchers.
+func (fc *adsFlowControl) setPending() {
+	fc.pending.Store(true)
+}
+
+// wait blocks until all the watchers have consumed the most recent update and
+// returns true. If the context expires before that, it returns false.
+func (fc *adsFlowControl) wait(ctx context.Context) bool {
+	// If there is no pending update, there is no need to block.
+	if !fc.pending.Load() {
+		// If all watchers finished processing the most recent update before the
+		// `recv` goroutine made the next call to `Wait()`, there would be an
+		// entry in the readyCh channel that needs to be drained to ensure that
+		// the next call to `Wait()` doesn't unblock before it actually should.
+		select {
+		case <-fc.readyCh:
+		default:
+		}
+		return true
+	}
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-fc.readyCh:
+		return true
+	}
+}
+
+// onDone indicates that all watchers have consumed the most recent update.
+func (fc *adsFlowControl) onDone() {
+	select {
+	// Writes to the readyCh channel should not block ideally. The default
+	// branch here is to appease the paranoid mind.
+	case fc.readyCh <- struct{}{}:
+	default:
+		if fc.logger.V(2) {
+			fc.logger.Infof("ADS stream flow control readyCh is full")
+		}
+	}
+	fc.pending.Store(false)
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/clientutils/metadata.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/clientutils/metadata.go
@@ -1,0 +1,40 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package clientutils
+
+import (
+	"context"
+
+	"google.golang.org/grpc/metadata"
+)
+
+type mdExtraKey struct{}
+
+// WithExtraMetadata creates a new context with incoming md attached.
+func WithExtraMetadata(ctx context.Context, md metadata.MD) context.Context {
+	return context.WithValue(ctx, mdExtraKey{}, md)
+}
+
+// ExtraMetadata returns the incoming metadata in ctx if it exists.  The
+// returned MD should not be modified. Writing to it may cause races.
+// Modification should be made to copies of the returned MD.
+func ExtraMetadata(ctx context.Context) (md metadata.MD, ok bool) {
+	md, ok = ctx.Value(mdExtraKey{}).(metadata.MD)
+	return
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/clientutils/regex.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/clientutils/regex.go
@@ -1,0 +1,32 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package clientutils contains helpers for xDS client testing.
+package clientutils
+
+import "regexp"
+
+// FullMatchWithRegex returns whether the full text matches the regex provided.
+func FullMatchWithRegex(re *regexp.Regexp, text string) bool {
+	if len(text) == 0 {
+		return re.MatchString(text)
+	}
+	re.Longest()
+	rem := re.FindString(text)
+	return len(rem) == len(text)
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/filter_chain.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/filter_chain.go
@@ -1,0 +1,893 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync/atomic"
+
+	"google.golang.org/grpc/internal/resolver"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/httpfilter"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/xdsresource"
+	"google.golang.org/protobuf/proto"
+
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+)
+
+const (
+	// Used as the map key for unspecified prefixes. The actual value of this
+	// key is immaterial.
+	unspecifiedPrefixMapKey = "unspecified"
+
+	// An unspecified destination or source prefix should be considered a less
+	// specific match than a wildcard prefix, `0.0.0.0/0` or `::/0`. Also, an
+	// unspecified prefix should match most v4 and v6 addresses compared to the
+	// wildcard prefixes which match only a specific network (v4 or v6).
+	//
+	// We use these constants when looking up the most specific prefix match. A
+	// wildcard prefix will match 0 bits, and to make sure that a wildcard
+	// prefix is considered a more specific match than an unspecified prefix, we
+	// use a value of -1 for the latter.
+	noPrefixMatch          = -2
+	unspecifiedPrefixMatch = -1
+)
+
+// FilterChain captures information from within a FilterChain message in a
+// Listener resource.
+type FilterChain struct {
+	// SecurityCfg contains transport socket security configuration.
+	SecurityCfg *SecurityConfig
+	// HTTPFilters represent the HTTP Filters that comprise this FilterChain.
+	HTTPFilters []HTTPFilter
+	// RouteConfigName is the route configuration name for this FilterChain.
+	//
+	// Exactly one of RouteConfigName and InlineRouteConfig is set.
+	RouteConfigName string
+	// InlineRouteConfig is the inline route configuration (RDS response)
+	// returned for this filter chain.
+	//
+	// Exactly one of RouteConfigName and InlineRouteConfig is set.
+	InlineRouteConfig *RouteConfigUpdate
+	// UsableRouteConfiguration is the routing configuration for this filter
+	// chain (LDS + RDS).
+	UsableRouteConfiguration *atomic.Pointer[UsableRouteConfiguration]
+}
+
+// VirtualHostWithInterceptors captures information present in a VirtualHost
+// update, and also contains routes with instantiated HTTP Filters.
+type VirtualHostWithInterceptors struct {
+	// Domains are the domain names which map to this Virtual Host. On the
+	// server side, this will be dictated by the :authority header of the
+	// incoming RPC.
+	Domains []string
+	// Routes are the Routes for this Virtual Host.
+	Routes []RouteWithInterceptors
+}
+
+// RouteWithInterceptors captures information in a Route, and contains
+// a usable matcher and also instantiated HTTP Filters.
+type RouteWithInterceptors struct {
+	// M is the matcher used to match to this route.
+	M *CompositeMatcher
+	// ActionType is the type of routing action to initiate once matched to.
+	ActionType RouteActionType
+	// Interceptors are interceptors instantiated for this route. These will be
+	// constructed from a combination of the top level configuration and any
+	// HTTP Filter overrides present in Virtual Host or Route.
+	Interceptors []resolver.ServerInterceptor
+}
+
+// UsableRouteConfiguration contains a matchable route configuration, with
+// instantiated HTTP Filters per route.
+type UsableRouteConfiguration struct {
+	VHS []VirtualHostWithInterceptors
+	Err error
+}
+
+// ConstructUsableRouteConfiguration takes Route Configuration and converts it
+// into matchable route configuration, with instantiated HTTP Filters per route.
+func (fc *FilterChain) ConstructUsableRouteConfiguration(config RouteConfigUpdate) *UsableRouteConfiguration {
+	vhs := make([]VirtualHostWithInterceptors, 0, len(config.VirtualHosts))
+	for _, vh := range config.VirtualHosts {
+		vhwi, err := fc.convertVirtualHost(vh)
+		if err != nil {
+			// Non nil if (lds + rds) fails, shouldn't happen since validated by
+			// xDS Client, treat as L7 error but shouldn't happen.
+			return &UsableRouteConfiguration{Err: fmt.Errorf("virtual host construction: %v", err)}
+		}
+		vhs = append(vhs, vhwi)
+	}
+	return &UsableRouteConfiguration{VHS: vhs}
+}
+
+func (fc *FilterChain) convertVirtualHost(virtualHost *VirtualHost) (VirtualHostWithInterceptors, error) {
+	rs := make([]RouteWithInterceptors, len(virtualHost.Routes))
+	for i, r := range virtualHost.Routes {
+		rs[i].ActionType = r.ActionType
+		rs[i].M = RouteToMatcher(r)
+		for _, filter := range fc.HTTPFilters {
+			// Route is highest priority on server side, as there is no concept
+			// of an upstream cluster on server side.
+			override := r.HTTPFilterConfigOverride[filter.Name]
+			if override == nil {
+				// Virtual Host is second priority.
+				override = virtualHost.HTTPFilterConfigOverride[filter.Name]
+			}
+			sb, ok := filter.Filter.(httpfilter.ServerInterceptorBuilder)
+			if !ok {
+				// Should not happen if it passed xdsClient validation.
+				return VirtualHostWithInterceptors{}, fmt.Errorf("filter does not support use in server")
+			}
+			si, err := sb.BuildServerInterceptor(filter.Config, override)
+			if err != nil {
+				return VirtualHostWithInterceptors{}, fmt.Errorf("filter construction: %v", err)
+			}
+			if si != nil {
+				rs[i].Interceptors = append(rs[i].Interceptors, si)
+			}
+		}
+	}
+	return VirtualHostWithInterceptors{Domains: virtualHost.Domains, Routes: rs}, nil
+}
+
+// SourceType specifies the connection source IP match type.
+type SourceType int
+
+const (
+	// SourceTypeAny matches connection attempts from any source.
+	SourceTypeAny SourceType = iota
+	// SourceTypeSameOrLoopback matches connection attempts from the same host.
+	SourceTypeSameOrLoopback
+	// SourceTypeExternal matches connection attempts from a different host.
+	SourceTypeExternal
+)
+
+// FilterChainManager contains all the match criteria specified through all
+// filter chains in a single Listener resource. It also contains the default
+// filter chain specified in the Listener resource. It provides two important
+// pieces of functionality:
+//  1. Validate the filter chains in an incoming Listener resource to make sure
+//     that there aren't filter chains which contain the same match criteria.
+//  2. As part of performing the above validation, it builds an internal data
+//     structure which will if used to look up the matching filter chain at
+//     connection time.
+//
+// The logic specified in the documentation around the xDS FilterChainMatch
+// proto mentions 8 criteria to match on.
+// The following order applies:
+//
+// 1. Destination port.
+// 2. Destination IP address.
+// 3. Server name (e.g. SNI for TLS protocol),
+// 4. Transport protocol.
+// 5. Application protocols (e.g. ALPN for TLS protocol).
+// 6. Source type (e.g. any, local or external network).
+// 7. Source IP address.
+// 8. Source port.
+type FilterChainManager struct {
+	// Destination prefix is the first match criteria that we support.
+	// Therefore, this multi-stage map is indexed on destination prefixes
+	// specified in the match criteria.
+	// Unspecified destination prefix matches end up as a wildcard entry here
+	// with a key of 0.0.0.0/0.
+	dstPrefixMap map[string]*destPrefixEntry
+
+	// At connection time, we do not have the actual destination prefix to match
+	// on. We only have the real destination address of the incoming connection.
+	// This means that we cannot use the above map at connection time. This list
+	// contains the map entries from the above map that we can use at connection
+	// time to find matching destination prefixes in O(n) time.
+	//
+	// TODO: Implement LC-trie to support logarithmic time lookups. If that
+	// involves too much time/effort, sort this slice based on the netmask size.
+	dstPrefixes []*destPrefixEntry
+
+	def *FilterChain // Default filter chain, if specified.
+
+	// Slice of filter chains managed by this filter chain manager.
+	fcs []*FilterChain
+
+	// RouteConfigNames are the route configuration names which need to be
+	// dynamically queried for RDS Configuration for any FilterChains which
+	// specify to load RDS Configuration dynamically.
+	RouteConfigNames map[string]bool
+}
+
+// destPrefixEntry is the value type of the map indexed on destination prefixes.
+type destPrefixEntry struct {
+	// The actual destination prefix. Set to nil for unspecified prefixes.
+	net *net.IPNet
+	// We need to keep track of the transport protocols seen as part of the
+	// config validation (and internal structure building) phase. The only two
+	// values that we support are empty string and "raw_buffer", with the latter
+	// taking preference. Once we have seen one filter chain with "raw_buffer",
+	// we can drop everything other filter chain with an empty transport
+	// protocol.
+	rawBufferSeen bool
+	// For each specified source type in the filter chain match criteria, this
+	// array points to the set of specified source prefixes.
+	// Unspecified source type matches end up as a wildcard entry here with an
+	// index of 0, which actually represents the source type `ANY`.
+	srcTypeArr sourceTypesArray
+}
+
+// An array for the fixed number of source types that we have.
+type sourceTypesArray [3]*sourcePrefixes
+
+// sourcePrefixes contains source prefix related information specified in the
+// match criteria. These are pointed to by the array of source types.
+type sourcePrefixes struct {
+	// These are very similar to the 'dstPrefixMap' and 'dstPrefixes' field of
+	// FilterChainManager. Go there for more info.
+	srcPrefixMap map[string]*sourcePrefixEntry
+	srcPrefixes  []*sourcePrefixEntry
+}
+
+// sourcePrefixEntry contains match criteria per source prefix.
+type sourcePrefixEntry struct {
+	// The actual destination prefix. Set to nil for unspecified prefixes.
+	net *net.IPNet
+	// Mapping from source ports specified in the match criteria to the actual
+	// filter chain. Unspecified source port matches en up as a wildcard entry
+	// here with a key of 0.
+	srcPortMap map[int]*FilterChain
+}
+
+// NewFilterChainManager parses the received Listener resource and builds a
+// FilterChainManager. Returns a non-nil error on validation failures.
+//
+// This function is only exported so that tests outside of this package can
+// create a FilterChainManager.
+func NewFilterChainManager(lis *v3listenerpb.Listener) (*FilterChainManager, error) {
+	// Parse all the filter chains and build the internal data structures.
+	fci := &FilterChainManager{
+		dstPrefixMap:     make(map[string]*destPrefixEntry),
+		RouteConfigNames: make(map[string]bool),
+	}
+	if err := fci.addFilterChains(lis.GetFilterChains()); err != nil {
+		return nil, err
+	}
+	// Build the source and dest prefix slices used by Lookup().
+	fcSeen := false
+	for _, dstPrefix := range fci.dstPrefixMap {
+		fci.dstPrefixes = append(fci.dstPrefixes, dstPrefix)
+		for _, st := range dstPrefix.srcTypeArr {
+			if st == nil {
+				continue
+			}
+			for _, srcPrefix := range st.srcPrefixMap {
+				st.srcPrefixes = append(st.srcPrefixes, srcPrefix)
+				for _, fc := range srcPrefix.srcPortMap {
+					if fc != nil {
+						fcSeen = true
+					}
+				}
+			}
+		}
+	}
+
+	// Retrieve the default filter chain. The match criteria specified on the
+	// default filter chain is never used. The default filter chain simply gets
+	// used when none of the other filter chains match.
+	var def *FilterChain
+	if dfc := lis.GetDefaultFilterChain(); dfc != nil {
+		var err error
+		if def, err = fci.filterChainFromProto(dfc); err != nil {
+			return nil, err
+		}
+	}
+	fci.def = def
+	if fci.def != nil {
+		fci.fcs = append(fci.fcs, fci.def)
+	}
+
+	// If there are no supported filter chains and no default filter chain, we
+	// fail here. This will call the Listener resource to be NACK'ed.
+	if !fcSeen && fci.def == nil {
+		return nil, fmt.Errorf("no supported filter chains and no default filter chain")
+	}
+	return fci, nil
+}
+
+// addFilterChains parses the filter chains in fcs and adds the required
+// internal data structures corresponding to the match criteria.
+func (fcm *FilterChainManager) addFilterChains(fcs []*v3listenerpb.FilterChain) error {
+	for _, fc := range fcs {
+		fcMatch := fc.GetFilterChainMatch()
+		if fcMatch.GetDestinationPort().GetValue() != 0 {
+			// Destination port is the first match criteria and we do not
+			// support filter chains which contains this match criteria.
+			logger.Warningf("Dropping filter chain %+v since it contains unsupported destination_port match field", fc)
+			continue
+		}
+
+		// Build the internal representation of the filter chain match fields.
+		if err := fcm.addFilterChainsForDestPrefixes(fc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (fcm *FilterChainManager) addFilterChainsForDestPrefixes(fc *v3listenerpb.FilterChain) error {
+	ranges := fc.GetFilterChainMatch().GetPrefixRanges()
+	dstPrefixes := make([]*net.IPNet, 0, len(ranges))
+	for _, pr := range ranges {
+		cidr := fmt.Sprintf("%s/%d", pr.GetAddressPrefix(), pr.GetPrefixLen().GetValue())
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return fmt.Errorf("failed to parse destination prefix range: %+v", pr)
+		}
+		dstPrefixes = append(dstPrefixes, ipnet)
+	}
+
+	if len(dstPrefixes) == 0 {
+		// Use the unspecified entry when destination prefix is unspecified, and
+		// set the `net` field to nil.
+		if fcm.dstPrefixMap[unspecifiedPrefixMapKey] == nil {
+			fcm.dstPrefixMap[unspecifiedPrefixMapKey] = &destPrefixEntry{}
+		}
+		return fcm.addFilterChainsForServerNames(fcm.dstPrefixMap[unspecifiedPrefixMapKey], fc)
+	}
+	for _, prefix := range dstPrefixes {
+		p := prefix.String()
+		if fcm.dstPrefixMap[p] == nil {
+			fcm.dstPrefixMap[p] = &destPrefixEntry{net: prefix}
+		}
+		if err := fcm.addFilterChainsForServerNames(fcm.dstPrefixMap[p], fc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fcm *FilterChainManager) addFilterChainsForServerNames(dstEntry *destPrefixEntry, fc *v3listenerpb.FilterChain) error {
+	// Filter chains specifying server names in their match criteria always fail
+	// a match at connection time. So, these filter chains can be dropped now.
+	if len(fc.GetFilterChainMatch().GetServerNames()) != 0 {
+		logger.Warningf("Dropping filter chain %+v since it contains unsupported server_names match field", fc)
+		return nil
+	}
+
+	return fcm.addFilterChainsForTransportProtocols(dstEntry, fc)
+}
+
+func (fcm *FilterChainManager) addFilterChainsForTransportProtocols(dstEntry *destPrefixEntry, fc *v3listenerpb.FilterChain) error {
+	tp := fc.GetFilterChainMatch().GetTransportProtocol()
+	switch {
+	case tp != "" && tp != "raw_buffer":
+		// Only allow filter chains with transport protocol set to empty string
+		// or "raw_buffer".
+		logger.Warningf("Dropping filter chain %+v since it contains unsupported value for transport_protocols match field", fc)
+		return nil
+	case tp == "" && dstEntry.rawBufferSeen:
+		// If we have already seen filter chains with transport protocol set to
+		// "raw_buffer", we can drop filter chains with transport protocol set
+		// to empty string, since the former takes precedence.
+		logger.Warningf("Dropping filter chain %+v since it contains unsupported value for transport_protocols match field", fc)
+		return nil
+	case tp != "" && !dstEntry.rawBufferSeen:
+		// This is the first "raw_buffer" that we are seeing. Set the bit and
+		// reset the source types array which might contain entries for filter
+		// chains with transport protocol set to empty string.
+		dstEntry.rawBufferSeen = true
+		dstEntry.srcTypeArr = sourceTypesArray{}
+	}
+	return fcm.addFilterChainsForApplicationProtocols(dstEntry, fc)
+}
+
+func (fcm *FilterChainManager) addFilterChainsForApplicationProtocols(dstEntry *destPrefixEntry, fc *v3listenerpb.FilterChain) error {
+	if len(fc.GetFilterChainMatch().GetApplicationProtocols()) != 0 {
+		logger.Warningf("Dropping filter chain %+v since it contains unsupported application_protocols match field", fc)
+		return nil
+	}
+	return fcm.addFilterChainsForSourceType(dstEntry, fc)
+}
+
+// addFilterChainsForSourceType adds source types to the internal data
+// structures and delegates control to addFilterChainsForSourcePrefixes to
+// continue building the internal data structure.
+func (fcm *FilterChainManager) addFilterChainsForSourceType(dstEntry *destPrefixEntry, fc *v3listenerpb.FilterChain) error {
+	var srcType SourceType
+	switch st := fc.GetFilterChainMatch().GetSourceType(); st {
+	case v3listenerpb.FilterChainMatch_ANY:
+		srcType = SourceTypeAny
+	case v3listenerpb.FilterChainMatch_SAME_IP_OR_LOOPBACK:
+		srcType = SourceTypeSameOrLoopback
+	case v3listenerpb.FilterChainMatch_EXTERNAL:
+		srcType = SourceTypeExternal
+	default:
+		return fmt.Errorf("unsupported source type: %v", st)
+	}
+
+	st := int(srcType)
+	if dstEntry.srcTypeArr[st] == nil {
+		dstEntry.srcTypeArr[st] = &sourcePrefixes{srcPrefixMap: make(map[string]*sourcePrefixEntry)}
+	}
+	return fcm.addFilterChainsForSourcePrefixes(dstEntry.srcTypeArr[st].srcPrefixMap, fc)
+}
+
+// addFilterChainsForSourcePrefixes adds source prefixes to the internal data
+// structures and delegates control to addFilterChainsForSourcePorts to continue
+// building the internal data structure.
+func (fcm *FilterChainManager) addFilterChainsForSourcePrefixes(srcPrefixMap map[string]*sourcePrefixEntry, fc *v3listenerpb.FilterChain) error {
+	ranges := fc.GetFilterChainMatch().GetSourcePrefixRanges()
+	srcPrefixes := make([]*net.IPNet, 0, len(ranges))
+	for _, pr := range fc.GetFilterChainMatch().GetSourcePrefixRanges() {
+		cidr := fmt.Sprintf("%s/%d", pr.GetAddressPrefix(), pr.GetPrefixLen().GetValue())
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return fmt.Errorf("failed to parse source prefix range: %+v", pr)
+		}
+		srcPrefixes = append(srcPrefixes, ipnet)
+	}
+
+	if len(srcPrefixes) == 0 {
+		// Use the unspecified entry when destination prefix is unspecified, and
+		// set the `net` field to nil.
+		if srcPrefixMap[unspecifiedPrefixMapKey] == nil {
+			srcPrefixMap[unspecifiedPrefixMapKey] = &sourcePrefixEntry{
+				srcPortMap: make(map[int]*FilterChain),
+			}
+		}
+		return fcm.addFilterChainsForSourcePorts(srcPrefixMap[unspecifiedPrefixMapKey], fc)
+	}
+	for _, prefix := range srcPrefixes {
+		p := prefix.String()
+		if srcPrefixMap[p] == nil {
+			srcPrefixMap[p] = &sourcePrefixEntry{
+				net:        prefix,
+				srcPortMap: make(map[int]*FilterChain),
+			}
+		}
+		if err := fcm.addFilterChainsForSourcePorts(srcPrefixMap[p], fc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addFilterChainsForSourcePorts adds source ports to the internal data
+// structures and completes the process of building the internal data structure.
+// It is here that we determine if there are multiple filter chains with
+// overlapping matching rules.
+func (fcm *FilterChainManager) addFilterChainsForSourcePorts(srcEntry *sourcePrefixEntry, fcProto *v3listenerpb.FilterChain) error {
+	ports := fcProto.GetFilterChainMatch().GetSourcePorts()
+	srcPorts := make([]int, 0, len(ports))
+	for _, port := range ports {
+		srcPorts = append(srcPorts, int(port))
+	}
+
+	fc, err := fcm.filterChainFromProto(fcProto)
+	if err != nil {
+		return err
+	}
+
+	if len(srcPorts) == 0 {
+		// Use the wildcard port '0', when source ports are unspecified.
+		if curFC := srcEntry.srcPortMap[0]; curFC != nil {
+			return errors.New("multiple filter chains with overlapping matching rules are defined")
+		}
+		srcEntry.srcPortMap[0] = fc
+		fcm.fcs = append(fcm.fcs, fc)
+		return nil
+	}
+	for _, port := range srcPorts {
+		if curFC := srcEntry.srcPortMap[port]; curFC != nil {
+			return errors.New("multiple filter chains with overlapping matching rules are defined")
+		}
+		srcEntry.srcPortMap[port] = fc
+	}
+	fcm.fcs = append(fcm.fcs, fc)
+	return nil
+}
+
+// FilterChains returns the filter chains for this filter chain manager.
+func (fcm *FilterChainManager) FilterChains() []*FilterChain {
+	return fcm.fcs
+}
+
+// filterChainFromProto extracts the relevant information from the FilterChain
+// proto and stores it in our internal representation. It also persists any
+// RouteNames which need to be queried dynamically via RDS.
+func (fcm *FilterChainManager) filterChainFromProto(fc *v3listenerpb.FilterChain) (*FilterChain, error) {
+	filterChain, err := processNetworkFilters(fc.GetFilters())
+	if err != nil {
+		return nil, err
+	}
+	// These route names will be dynamically queried via RDS in the wrapped
+	// listener, which receives the LDS response, if specified for the filter
+	// chain.
+	if filterChain.RouteConfigName != "" {
+		fcm.RouteConfigNames[filterChain.RouteConfigName] = true
+	}
+	// If the transport_socket field is not specified, it means that the control
+	// plane has not sent us any security config. This is fine and the server
+	// will use the fallback credentials configured as part of the
+	// xdsCredentials.
+	ts := fc.GetTransportSocket()
+	if ts == nil {
+		return filterChain, nil
+	}
+	if name := ts.GetName(); name != transportSocketName {
+		return nil, fmt.Errorf("transport_socket field has unexpected name: %s", name)
+	}
+	tc := ts.GetTypedConfig()
+	if tc == nil || tc.TypeUrl != xdsresource.V3DownstreamTLSContextURL {
+		return nil, fmt.Errorf("transport_socket field has unexpected typeURL: %s", tc.TypeUrl)
+	}
+	downstreamCtx := &v3tlspb.DownstreamTlsContext{}
+	if err := proto.Unmarshal(tc.GetValue(), downstreamCtx); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal DownstreamTlsContext in LDS response: %v", err)
+	}
+	if downstreamCtx.GetRequireSni().GetValue() {
+		return nil, fmt.Errorf("require_sni field set to true in DownstreamTlsContext message: %v", downstreamCtx)
+	}
+	if downstreamCtx.GetOcspStaplePolicy() != v3tlspb.DownstreamTlsContext_LENIENT_STAPLING {
+		return nil, fmt.Errorf("ocsp_staple_policy field set to unsupported value in DownstreamTlsContext message: %v", downstreamCtx)
+	}
+	// The following fields from `DownstreamTlsContext` are ignore:
+	// - disable_stateless_session_resumption
+	// - session_ticket_keys
+	// - session_ticket_keys_sds_secret_config
+	// - session_timeout
+	if downstreamCtx.GetCommonTlsContext() == nil {
+		return nil, errors.New("DownstreamTlsContext in LDS response does not contain a CommonTlsContext")
+	}
+	sc, err := securityConfigFromCommonTLSContext(downstreamCtx.GetCommonTlsContext(), true)
+	if err != nil {
+		return nil, err
+	}
+	if sc == nil {
+		// sc == nil is a valid case where the control plane has not sent us any
+		// security configuration. xDS creds will use fallback creds.
+		return filterChain, nil
+	}
+	sc.RequireClientCert = downstreamCtx.GetRequireClientCertificate().GetValue()
+	if sc.RequireClientCert && sc.RootInstanceName == "" {
+		return nil, errors.New("security configuration on the server-side does not contain root certificate provider instance name, but require_client_cert field is set")
+	}
+	filterChain.SecurityCfg = sc
+	return filterChain, nil
+}
+
+// Validate takes a function to validate the FilterChains in this manager.
+func (fcm *FilterChainManager) Validate(f func(fc *FilterChain) error) error {
+	for _, dst := range fcm.dstPrefixMap {
+		for _, srcType := range dst.srcTypeArr {
+			if srcType == nil {
+				continue
+			}
+			for _, src := range srcType.srcPrefixMap {
+				for _, fc := range src.srcPortMap {
+					if err := f(fc); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return f(fcm.def)
+}
+
+func processNetworkFilters(filters []*v3listenerpb.Filter) (*FilterChain, error) {
+	rc := &UsableRouteConfiguration{}
+	filterChain := &FilterChain{
+		UsableRouteConfiguration: &atomic.Pointer[UsableRouteConfiguration]{},
+	}
+	filterChain.UsableRouteConfiguration.Store(rc)
+	seenNames := make(map[string]bool, len(filters))
+	seenHCM := false
+	for _, filter := range filters {
+		name := filter.GetName()
+		if name == "" {
+			return nil, fmt.Errorf("network filters {%+v} is missing name field in filter: {%+v}", filters, filter)
+		}
+		if seenNames[name] {
+			return nil, fmt.Errorf("network filters {%+v} has duplicate filter name %q", filters, name)
+		}
+		seenNames[name] = true
+
+		// Network filters have a oneof field named `config_type` where we
+		// only support `TypedConfig` variant.
+		switch typ := filter.GetConfigType().(type) {
+		case *v3listenerpb.Filter_TypedConfig:
+			// The typed_config field has an `anypb.Any` proto which could
+			// directly contain the serialized bytes of the actual filter
+			// configuration, or it could be encoded as a `TypedStruct`.
+			// TODO: Add support for `TypedStruct`.
+			tc := filter.GetTypedConfig()
+
+			// The only network filter that we currently support is the v3
+			// HttpConnectionManager. So, we can directly check the type_url
+			// and unmarshal the config.
+			// TODO: Implement a registry of supported network filters (like
+			// we have for HTTP filters), when we have to support network
+			// filters other than HttpConnectionManager.
+			if tc.GetTypeUrl() != xdsresource.V3HTTPConnManagerURL {
+				return nil, fmt.Errorf("network filters {%+v} has unsupported network filter %q in filter {%+v}", filters, tc.GetTypeUrl(), filter)
+			}
+			hcm := &v3httppb.HttpConnectionManager{}
+			if err := tc.UnmarshalTo(hcm); err != nil {
+				return nil, fmt.Errorf("network filters {%+v} failed unmarshalling of network filter {%+v}: %v", filters, filter, err)
+			}
+			// "Any filters after HttpConnectionManager should be ignored during
+			// connection processing but still be considered for validity.
+			// HTTPConnectionManager must have valid http_filters." - A36
+			filters, err := processHTTPFilters(hcm.GetHttpFilters(), true)
+			if err != nil {
+				return nil, fmt.Errorf("network filters {%+v} had invalid server side HTTP Filters {%+v}: %v", filters, hcm.GetHttpFilters(), err)
+			}
+			if !seenHCM {
+				// Validate for RBAC in only the HCM that will be used, since this isn't a logical validation failure,
+				// it's simply a validation to support RBAC HTTP Filter.
+				// "HttpConnectionManager.xff_num_trusted_hops must be unset or zero and
+				// HttpConnectionManager.original_ip_detection_extensions must be empty. If
+				// either field has an incorrect value, the Listener must be NACKed." - A41
+				if hcm.XffNumTrustedHops != 0 {
+					return nil, fmt.Errorf("xff_num_trusted_hops must be unset or zero %+v", hcm)
+				}
+				if len(hcm.OriginalIpDetectionExtensions) != 0 {
+					return nil, fmt.Errorf("original_ip_detection_extensions must be empty %+v", hcm)
+				}
+
+				// TODO: Implement terminal filter logic, as per A36.
+				filterChain.HTTPFilters = filters
+				seenHCM = true
+				switch hcm.RouteSpecifier.(type) {
+				case *v3httppb.HttpConnectionManager_Rds:
+					if hcm.GetRds().GetConfigSource().GetAds() == nil {
+						return nil, fmt.Errorf("ConfigSource is not ADS: %+v", hcm)
+					}
+					name := hcm.GetRds().GetRouteConfigName()
+					if name == "" {
+						return nil, fmt.Errorf("empty route_config_name: %+v", hcm)
+					}
+					filterChain.RouteConfigName = name
+				case *v3httppb.HttpConnectionManager_RouteConfig:
+					// "RouteConfiguration validation logic inherits all
+					// previous validations made for client-side usage as RDS
+					// does not distinguish between client-side and
+					// server-side." - A36
+					// Can specify v3 here, as will never get to this function
+					// if v2.
+					routeU, err := generateRDSUpdateFromRouteConfiguration(hcm.GetRouteConfig())
+					if err != nil {
+						return nil, fmt.Errorf("failed to parse inline RDS resp: %v", err)
+					}
+					filterChain.InlineRouteConfig = &routeU
+				case nil:
+					return nil, fmt.Errorf("no RouteSpecifier: %+v", hcm)
+				default:
+					return nil, fmt.Errorf("unsupported type %T for RouteSpecifier", hcm.RouteSpecifier)
+				}
+			}
+		default:
+			return nil, fmt.Errorf("network filters {%+v} has unsupported config_type %T in filter %s", filters, typ, filter.GetName())
+		}
+	}
+	if !seenHCM {
+		return nil, fmt.Errorf("network filters {%+v} missing HttpConnectionManager filter", filters)
+	}
+	return filterChain, nil
+}
+
+// FilterChainLookupParams wraps parameters to be passed to Lookup.
+type FilterChainLookupParams struct {
+	// IsUnspecified indicates whether the server is listening on a wildcard
+	// address, "0.0.0.0" for IPv4 and "::" for IPv6. Only when this is set to
+	// true, do we consider the destination prefixes specified in the filter
+	// chain match criteria.
+	IsUnspecifiedListener bool
+	// DestAddr is the local address of an incoming connection.
+	DestAddr net.IP
+	// SourceAddr is the remote address of an incoming connection.
+	SourceAddr net.IP
+	// SourcePort is the remote port of an incoming connection.
+	SourcePort int
+}
+
+// Lookup returns the most specific matching filter chain to be used for an
+// incoming connection on the server side.
+//
+// Returns a non-nil error if no matching filter chain could be found or
+// multiple matching filter chains were found, and in both cases, the incoming
+// connection must be dropped.
+func (fcm *FilterChainManager) Lookup(params FilterChainLookupParams) (*FilterChain, error) {
+	dstPrefixes := filterByDestinationPrefixes(fcm.dstPrefixes, params.IsUnspecifiedListener, params.DestAddr)
+	if len(dstPrefixes) == 0 {
+		if fcm.def != nil {
+			return fcm.def, nil
+		}
+		return nil, fmt.Errorf("no matching filter chain based on destination prefix match for %+v", params)
+	}
+
+	srcType := SourceTypeExternal
+	if params.SourceAddr.Equal(params.DestAddr) || params.SourceAddr.IsLoopback() {
+		srcType = SourceTypeSameOrLoopback
+	}
+	srcPrefixes := filterBySourceType(dstPrefixes, srcType)
+	if len(srcPrefixes) == 0 {
+		if fcm.def != nil {
+			return fcm.def, nil
+		}
+		return nil, fmt.Errorf("no matching filter chain based on source type match for %+v", params)
+	}
+	srcPrefixEntry, err := filterBySourcePrefixes(srcPrefixes, params.SourceAddr)
+	if err != nil {
+		return nil, err
+	}
+	if fc := filterBySourcePorts(srcPrefixEntry, params.SourcePort); fc != nil {
+		return fc, nil
+	}
+	if fcm.def != nil {
+		return fcm.def, nil
+	}
+	return nil, fmt.Errorf("no matching filter chain after all match criteria for %+v", params)
+}
+
+// filterByDestinationPrefixes is the first stage of the filter chain
+// matching algorithm. It takes the complete set of configured filter chain
+// matchers and returns the most specific matchers based on the destination
+// prefix match criteria (the prefixes which match the most number of bits).
+func filterByDestinationPrefixes(dstPrefixes []*destPrefixEntry, isUnspecified bool, dstAddr net.IP) []*destPrefixEntry {
+	if !isUnspecified {
+		// Destination prefix matchers are considered only when the listener is
+		// bound to the wildcard address.
+		return dstPrefixes
+	}
+
+	var matchingDstPrefixes []*destPrefixEntry
+	maxSubnetMatch := noPrefixMatch
+	for _, prefix := range dstPrefixes {
+		if prefix.net != nil && !prefix.net.Contains(dstAddr) {
+			// Skip prefixes which don't match.
+			continue
+		}
+		// For unspecified prefixes, since we do not store a real net.IPNet
+		// inside prefix, we do not perform a match. Instead we simply set
+		// the matchSize to -1, which is less than the matchSize (0) for a
+		// wildcard prefix.
+		matchSize := unspecifiedPrefixMatch
+		if prefix.net != nil {
+			matchSize, _ = prefix.net.Mask.Size()
+		}
+		if matchSize < maxSubnetMatch {
+			continue
+		}
+		if matchSize > maxSubnetMatch {
+			maxSubnetMatch = matchSize
+			matchingDstPrefixes = make([]*destPrefixEntry, 0, 1)
+		}
+		matchingDstPrefixes = append(matchingDstPrefixes, prefix)
+	}
+	return matchingDstPrefixes
+}
+
+// filterBySourceType is the second stage of the matching algorithm. It
+// trims the filter chains based on the most specific source type match.
+func filterBySourceType(dstPrefixes []*destPrefixEntry, srcType SourceType) []*sourcePrefixes {
+	var (
+		srcPrefixes      []*sourcePrefixes
+		bestSrcTypeMatch int
+	)
+	for _, prefix := range dstPrefixes {
+		var (
+			srcPrefix *sourcePrefixes
+			match     int
+		)
+		switch srcType {
+		case SourceTypeExternal:
+			match = int(SourceTypeExternal)
+			srcPrefix = prefix.srcTypeArr[match]
+		case SourceTypeSameOrLoopback:
+			match = int(SourceTypeSameOrLoopback)
+			srcPrefix = prefix.srcTypeArr[match]
+		}
+		if srcPrefix == nil {
+			match = int(SourceTypeAny)
+			srcPrefix = prefix.srcTypeArr[match]
+		}
+		if match < bestSrcTypeMatch {
+			continue
+		}
+		if match > bestSrcTypeMatch {
+			bestSrcTypeMatch = match
+			srcPrefixes = make([]*sourcePrefixes, 0)
+		}
+		if srcPrefix != nil {
+			// The source type array always has 3 entries, but these could be
+			// nil if the appropriate source type match was not specified.
+			srcPrefixes = append(srcPrefixes, srcPrefix)
+		}
+	}
+	return srcPrefixes
+}
+
+// filterBySourcePrefixes is the third stage of the filter chain matching
+// algorithm. It trims the filter chains based on the source prefix. At most one
+// filter chain with the most specific match progress to the next stage.
+func filterBySourcePrefixes(srcPrefixes []*sourcePrefixes, srcAddr net.IP) (*sourcePrefixEntry, error) {
+	var matchingSrcPrefixes []*sourcePrefixEntry
+	maxSubnetMatch := noPrefixMatch
+	for _, sp := range srcPrefixes {
+		for _, prefix := range sp.srcPrefixes {
+			if prefix.net != nil && !prefix.net.Contains(srcAddr) {
+				// Skip prefixes which don't match.
+				continue
+			}
+			// For unspecified prefixes, since we do not store a real net.IPNet
+			// inside prefix, we do not perform a match. Instead we simply set
+			// the matchSize to -1, which is less than the matchSize (0) for a
+			// wildcard prefix.
+			matchSize := unspecifiedPrefixMatch
+			if prefix.net != nil {
+				matchSize, _ = prefix.net.Mask.Size()
+			}
+			if matchSize < maxSubnetMatch {
+				continue
+			}
+			if matchSize > maxSubnetMatch {
+				maxSubnetMatch = matchSize
+				matchingSrcPrefixes = make([]*sourcePrefixEntry, 0, 1)
+			}
+			matchingSrcPrefixes = append(matchingSrcPrefixes, prefix)
+		}
+	}
+	if len(matchingSrcPrefixes) == 0 {
+		// Finding no match is not an error condition. The caller will end up
+		// using the default filter chain if one was configured.
+		return nil, nil
+	}
+	// We expect at most a single matching source prefix entry at this point. If
+	// we have multiple entries here, and some of their source port matchers had
+	// wildcard entries, we could be left with more than one matching filter
+	// chain and hence would have been flagged as an invalid configuration at
+	// config validation time.
+	if len(matchingSrcPrefixes) != 1 {
+		return nil, errors.New("multiple matching filter chains")
+	}
+	return matchingSrcPrefixes[0], nil
+}
+
+// filterBySourcePorts is the last stage of the filter chain matching
+// algorithm. It trims the filter chains based on the source ports.
+func filterBySourcePorts(spe *sourcePrefixEntry, srcPort int) *FilterChain {
+	if spe == nil {
+		return nil
+	}
+	// A match could be a wildcard match (this happens when the match
+	// criteria does not specify source ports) or a specific port match (this
+	// happens when the match criteria specifies a set of ports and the source
+	// port of the incoming connection matches one of the specified ports). The
+	// latter is considered to be a more specific match.
+	if fc := spe.srcPortMap[srcPort]; fc != nil {
+		return fc
+	}
+	if fc := spe.srcPortMap[0]; fc != nil {
+		return fc
+	}
+	return nil
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/httpfilter/httpfilter.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/httpfilter/httpfilter.go
@@ -1,0 +1,108 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package httpfilter contains the HTTPFilter interface and a registry for
+// storing and retrieving their implementations.
+package httpfilter
+
+import (
+	iresolver "google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/resolver"
+	"google.golang.org/protobuf/proto"
+)
+
+// FilterConfig represents an opaque data structure holding configuration for a
+// filter.  Embed this interface to implement it.
+type FilterConfig interface {
+	isFilterConfig()
+}
+
+// Filter defines the parsing functionality of an HTTP filter.  A Filter may
+// optionally implement either ClientInterceptorBuilder or
+// ServerInterceptorBuilder or both, indicating it is capable of working on the
+// client side or server side or both, respectively.
+type Filter interface {
+	// TypeURLs are the proto message types supported by this filter.  A filter
+	// will be registered by each of its supported message types.
+	TypeURLs() []string
+	// ParseFilterConfig parses the provided configuration proto.Message from
+	// the LDS configuration of this filter.  This may be an anypb.Any, a
+	// udpa.type.v1.TypedStruct, or an xds.type.v3.TypedStruct for filters that
+	// do not accept a custom type. The resulting FilterConfig will later be
+	// passed to Build.
+	ParseFilterConfig(proto.Message) (FilterConfig, error)
+	// ParseFilterConfigOverride parses the provided override configuration
+	// proto.Message from the RDS override configuration of this filter.  This
+	// may be an anypb.Any, a udpa.type.v1.TypedStruct, or an
+	// xds.type.v3.TypedStruct for filters that do not accept a custom type.
+	// The resulting FilterConfig will later be passed to Build.
+	ParseFilterConfigOverride(proto.Message) (FilterConfig, error)
+	// IsTerminal returns whether this Filter is terminal or not (i.e. it must
+	// be last filter in the filter chain).
+	IsTerminal() bool
+}
+
+// ClientInterceptorBuilder constructs a Client Interceptor.  If this type is
+// implemented by a Filter, it is capable of working on a client.
+type ClientInterceptorBuilder interface {
+	// BuildClientInterceptor uses the FilterConfigs produced above to produce
+	// an HTTP filter interceptor for clients.  config will always be non-nil,
+	// but override may be nil if no override config exists for the filter.  It
+	// is valid for Build to return a nil Interceptor and a nil error.  In this
+	// case, the RPC will not be intercepted by this filter.
+	BuildClientInterceptor(config, override FilterConfig) (iresolver.ClientInterceptor, error)
+}
+
+// ServerInterceptorBuilder constructs a Server Interceptor.  If this type is
+// implemented by a Filter, it is capable of working on a server.
+type ServerInterceptorBuilder interface {
+	// BuildServerInterceptor uses the FilterConfigs produced above to produce
+	// an HTTP filter interceptor for servers.  config will always be non-nil,
+	// but override may be nil if no override config exists for the filter.  It
+	// is valid for Build to return a nil Interceptor and a nil error.  In this
+	// case, the RPC will not be intercepted by this filter.
+	BuildServerInterceptor(config, override FilterConfig) (iresolver.ServerInterceptor, error)
+}
+
+var (
+	// m is a map from scheme to filter.
+	m = make(map[string]Filter)
+)
+
+// Register registers the HTTP filter Builder to the filter map. b.TypeURLs()
+// will be used as the types for this filter.
+//
+// NOTE: this function must only be called during initialization time (i.e. in
+// an init() function), and is not thread-safe. If multiple filters are
+// registered with the same type URL, the one registered last will take effect.
+func Register(b Filter) {
+	for _, u := range b.TypeURLs() {
+		m[u] = b
+	}
+}
+
+// UnregisterForTesting unregisters the HTTP Filter for testing purposes.
+func UnregisterForTesting(typeURL string) {
+	delete(m, typeURL)
+}
+
+// Get returns the HTTPFilter registered with typeURL.
+//
+// If no filter is register with typeURL, nil will be returned.
+func Get(typeURL string) Filter {
+	return m[typeURL]
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/httpfilter/router/router.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/httpfilter/router/router.go
@@ -1,0 +1,113 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package router implements the Envoy Router HTTP filter.
+package router
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/httpfilter"
+	iresolver "google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/resolver"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+)
+
+// TypeURL is the message type for the Router configuration.
+const TypeURL = "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+
+func init() {
+	httpfilter.Register(builder{})
+}
+
+// IsRouterFilter returns true iff a HTTP filter is a Router filter.
+func IsRouterFilter(b httpfilter.Filter) bool {
+	_, ok := b.(builder)
+	return ok
+}
+
+type builder struct {
+}
+
+func (builder) TypeURLs() []string { return []string{TypeURL} }
+
+func (builder) ParseFilterConfig(cfg proto.Message) (httpfilter.FilterConfig, error) {
+	// The router filter does not currently use any fields from the
+	// config.  Verify type only.
+	if cfg == nil {
+		return nil, fmt.Errorf("router: nil configuration message provided")
+	}
+	m, ok := cfg.(*anypb.Any)
+	if !ok {
+		return nil, fmt.Errorf("router: error parsing config %v: unknown type %T", cfg, cfg)
+	}
+	msg := new(pb.Router)
+	if err := m.UnmarshalTo(msg); err != nil {
+		return nil, fmt.Errorf("router: error parsing config %v: %v", cfg, err)
+	}
+	return config{}, nil
+}
+
+func (builder) ParseFilterConfigOverride(override proto.Message) (httpfilter.FilterConfig, error) {
+	if override != nil {
+		return nil, fmt.Errorf("router: unexpected config override specified: %v", override)
+	}
+	return config{}, nil
+}
+
+func (builder) IsTerminal() bool {
+	return true
+}
+
+var (
+	_ httpfilter.ClientInterceptorBuilder = builder{}
+	_ httpfilter.ServerInterceptorBuilder = builder{}
+)
+
+func (builder) BuildClientInterceptor(cfg, override httpfilter.FilterConfig) (iresolver.ClientInterceptor, error) {
+	if _, ok := cfg.(config); !ok {
+		return nil, fmt.Errorf("router: incorrect config type provided (%T): %v", cfg, cfg)
+	}
+	if override != nil {
+		return nil, fmt.Errorf("router: unexpected override configuration specified: %v", override)
+	}
+	// The router is implemented within the xds resolver's config
+	// selector, not as a separate plugin.  So we return a nil HTTPFilter,
+	// which will not be invoked.
+	return nil, nil
+}
+
+func (builder) BuildServerInterceptor(cfg, override httpfilter.FilterConfig) (iresolver.ServerInterceptor, error) {
+	if _, ok := cfg.(config); !ok {
+		return nil, fmt.Errorf("router: incorrect config type provided (%T): %v", cfg, cfg)
+	}
+	if override != nil {
+		return nil, fmt.Errorf("router: unexpected override configuration specified: %v", override)
+	}
+	// The router is currently unimplemented on the server side. So we
+	// return a nil HTTPFilter, which will not be invoked.
+	return nil, nil
+}
+
+// The router filter does not currently support any configuration.  Verify
+// type only.
+type config struct {
+	httpfilter.FilterConfig
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/listener_resource_type.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/listener_resource_type.go
@@ -1,0 +1,113 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"bytes"
+
+	"google.golang.org/grpc/xds/internal/clients/internal/pretty"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/xdsresource"
+)
+
+const (
+	// ListenerResourceTypeName represents the transport agnostic name for the
+	// listener resource.
+	ListenerResourceTypeName = "ListenerResource"
+)
+
+type listenerDecoder struct{}
+
+var (
+	// Singleton instantiation of the resource type implementation.
+	listenerType = xdsclient.ResourceType{
+		TypeURL:                    xdsresource.V3ListenerURL,
+		TypeName:                   ListenerResourceTypeName,
+		AllResourcesRequiredInSotW: true,
+		Decoder:                    listenerDecoder{},
+	}
+)
+
+func listenerValidator(lis ListenerUpdate) error {
+	if lis.InboundListenerCfg == nil || lis.InboundListenerCfg.FilterChains == nil {
+		return nil
+	}
+	return lis.InboundListenerCfg.FilterChains.Validate(func(fc *FilterChain) error {
+		if fc == nil {
+			return nil
+		}
+		return nil
+	})
+}
+
+// Decode deserializes and validates an xDS resource serialized inside the
+// provided `Any` proto, as received from the xDS management server.
+func (listenerDecoder) Decode(resource []byte, _ xdsclient.DecodeOptions) (*xdsclient.DecodeResult, error) {
+	name, listener, err := unmarshalListenerResource(resource)
+	switch {
+	case name == "":
+		// Name is unset only when protobuf deserialization fails.
+		return nil, err
+	case err != nil:
+		// Protobuf deserialization succeeded, but resource validation failed.
+		return &xdsclient.DecodeResult{Name: name, Resource: &ListenerResourceData{Resource: ListenerUpdate{}}}, err
+	}
+
+	// Perform extra validation here.
+	if err := listenerValidator(listener); err != nil {
+		return &xdsclient.DecodeResult{Name: name, Resource: &ListenerResourceData{Resource: ListenerUpdate{}}}, err
+	}
+
+	return &xdsclient.DecodeResult{Name: name, Resource: &ListenerResourceData{Resource: listener}}, nil
+
+}
+
+// ListenerResourceData wraps the configuration of a Listener resource as
+// received from the management server.
+//
+// Implements the ResourceData interface.
+type ListenerResourceData struct {
+	xdsclient.ResourceData
+
+	// TODO: We have always stored update structs by value. See if this can be
+	// switched to a pointer?
+	Resource ListenerUpdate
+}
+
+// RawEqual returns true if other is equal to l.
+func (l *ListenerResourceData) RawEqual(other xdsclient.ResourceData) bool {
+	if l == nil && other == nil {
+		return true
+	}
+	if (l == nil) != (other == nil) {
+		return false
+	}
+	return bytes.Equal(l.Resource.Raw, other.Raw())
+
+}
+
+// ToJSON returns a JSON string representation of the resource data.
+func (l *ListenerResourceData) ToJSON() string {
+	return pretty.ToJSON(l.Resource)
+}
+
+// Raw returns the underlying raw protobuf form of the listener resource.
+func (l *ListenerResourceData) Raw() []byte {
+	return l.Resource.Raw
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/logger.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/logger.go
@@ -1,0 +1,28 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"google.golang.org/grpc/xds/internal/clients/clientslog"
+	internalclientslog "google.golang.org/grpc/xds/internal/clients/internal/clientslog"
+)
+
+const prefix = "[xds-resource] "
+
+var logger = internalclientslog.NewPrefixLogger(clientslog.Component("xds"), prefix)

--- a/xds/internal/clients/xdsclient/internal/testutils/matcher.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/matcher.go
@@ -1,0 +1,284 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package testutils
+
+import (
+	"fmt"
+	rand "math/rand/v2"
+	"strings"
+
+	"google.golang.org/grpc/metadata"
+	iresolver "google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/resolver"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/clientutils"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/matcher"
+)
+
+// RouteToMatcher converts a route to a Matcher to match incoming RPC's against.
+//
+// Only expected to be called on a Route that passed validation checks by the
+// xDS client.
+func RouteToMatcher(r *Route) *CompositeMatcher {
+	var pm pathMatcher
+	switch {
+	case r.Regex != nil:
+		pm = newPathRegexMatcher(r.Regex)
+	case r.Path != nil:
+		pm = newPathExactMatcher(*r.Path, r.CaseInsensitive)
+	case r.Prefix != nil:
+		pm = newPathPrefixMatcher(*r.Prefix, r.CaseInsensitive)
+	default:
+		panic("illegal route: missing path_matcher")
+	}
+
+	headerMatchers := make([]matcher.HeaderMatcher, 0, len(r.Headers))
+	for _, h := range r.Headers {
+		var matcherT matcher.HeaderMatcher
+		invert := h.InvertMatch != nil && *h.InvertMatch
+		switch {
+		case h.ExactMatch != nil && *h.ExactMatch != "":
+			matcherT = matcher.NewHeaderExactMatcher(h.Name, *h.ExactMatch, invert)
+		case h.RegexMatch != nil:
+			matcherT = matcher.NewHeaderRegexMatcher(h.Name, h.RegexMatch, invert)
+		case h.PrefixMatch != nil && *h.PrefixMatch != "":
+			matcherT = matcher.NewHeaderPrefixMatcher(h.Name, *h.PrefixMatch, invert)
+		case h.SuffixMatch != nil && *h.SuffixMatch != "":
+			matcherT = matcher.NewHeaderSuffixMatcher(h.Name, *h.SuffixMatch, invert)
+		case h.RangeMatch != nil:
+			matcherT = matcher.NewHeaderRangeMatcher(h.Name, h.RangeMatch.Start, h.RangeMatch.End, invert)
+		case h.PresentMatch != nil:
+			matcherT = matcher.NewHeaderPresentMatcher(h.Name, *h.PresentMatch, invert)
+		case h.StringMatch != nil:
+			matcherT = matcher.NewHeaderStringMatcher(h.Name, *h.StringMatch, invert)
+		default:
+			panic("illegal route: missing header_match_specifier")
+		}
+		headerMatchers = append(headerMatchers, matcherT)
+	}
+
+	var fractionMatcher *fractionMatcher
+	if r.Fraction != nil {
+		fractionMatcher = newFractionMatcher(*r.Fraction)
+	}
+	return newCompositeMatcher(pm, headerMatchers, fractionMatcher)
+}
+
+// CompositeMatcher is a matcher that holds onto many matchers and aggregates
+// the matching results.
+type CompositeMatcher struct {
+	pm  pathMatcher
+	hms []matcher.HeaderMatcher
+	fm  *fractionMatcher
+}
+
+func newCompositeMatcher(pm pathMatcher, hms []matcher.HeaderMatcher, fm *fractionMatcher) *CompositeMatcher {
+	return &CompositeMatcher{pm: pm, hms: hms, fm: fm}
+}
+
+// Match returns true if all matchers return true.
+func (a *CompositeMatcher) Match(info iresolver.RPCInfo) bool {
+	if a.pm != nil && !a.pm.match(info.Method) {
+		return false
+	}
+
+	// Call headerMatchers even if md is nil, because routes may match
+	// non-presence of some headers.
+	var md metadata.MD
+	if info.Context != nil {
+		md, _ = metadata.FromOutgoingContext(info.Context)
+		if extraMD, ok := clientutils.ExtraMetadata(info.Context); ok {
+			md = metadata.Join(md, extraMD)
+			// Remove all binary headers. They are hard to match with. May need
+			// to add back if asked by users.
+			for k := range md {
+				if strings.HasSuffix(k, "-bin") {
+					delete(md, k)
+				}
+			}
+		}
+	}
+	for _, m := range a.hms {
+		if !m.Match(md) {
+			return false
+		}
+	}
+
+	if a.fm != nil && !a.fm.match() {
+		return false
+	}
+	return true
+}
+
+func (a *CompositeMatcher) String() string {
+	var ret string
+	if a.pm != nil {
+		ret += a.pm.String()
+	}
+	for _, m := range a.hms {
+		ret += m.String()
+	}
+	if a.fm != nil {
+		ret += a.fm.String()
+	}
+	return ret
+}
+
+type fractionMatcher struct {
+	fraction int64 // real fraction is fraction/1,000,000.
+}
+
+func newFractionMatcher(fraction uint32) *fractionMatcher {
+	return &fractionMatcher{fraction: int64(fraction)}
+}
+
+// RandInt64n overwrites rand for control in tests.
+var RandInt64n = rand.Int64N
+
+func (fm *fractionMatcher) match() bool {
+	t := RandInt64n(1000000)
+	return t <= fm.fraction
+}
+
+func (fm *fractionMatcher) String() string {
+	return fmt.Sprintf("fraction:%v", fm.fraction)
+}
+
+type domainMatchType int
+
+const (
+	domainMatchTypeInvalid domainMatchType = iota
+	domainMatchTypeUniversal
+	domainMatchTypePrefix
+	domainMatchTypeSuffix
+	domainMatchTypeExact
+)
+
+// Exact > Suffix > Prefix > Universal > Invalid.
+func (t domainMatchType) betterThan(b domainMatchType) bool {
+	return t > b
+}
+
+func matchTypeForDomain(d string) domainMatchType {
+	if d == "" {
+		return domainMatchTypeInvalid
+	}
+	if d == "*" {
+		return domainMatchTypeUniversal
+	}
+	if strings.HasPrefix(d, "*") {
+		return domainMatchTypeSuffix
+	}
+	if strings.HasSuffix(d, "*") {
+		return domainMatchTypePrefix
+	}
+	if strings.Contains(d, "*") {
+		return domainMatchTypeInvalid
+	}
+	return domainMatchTypeExact
+}
+
+func match(domain, host string) (domainMatchType, bool) {
+	switch typ := matchTypeForDomain(domain); typ {
+	case domainMatchTypeInvalid:
+		return typ, false
+	case domainMatchTypeUniversal:
+		return typ, true
+	case domainMatchTypePrefix:
+		// abc.*
+		return typ, strings.HasPrefix(host, strings.TrimSuffix(domain, "*"))
+	case domainMatchTypeSuffix:
+		// *.123
+		return typ, strings.HasSuffix(host, strings.TrimPrefix(domain, "*"))
+	case domainMatchTypeExact:
+		return typ, domain == host
+	default:
+		return domainMatchTypeInvalid, false
+	}
+}
+
+// FindBestMatchingVirtualHost returns the virtual host whose domains field best
+// matches host
+//
+//	The domains field support 4 different matching pattern types:
+//
+//	- Exact match
+//	- Suffix match (e.g. “*ABC”)
+//	- Prefix match (e.g. “ABC*)
+//	- Universal match (e.g. “*”)
+//
+//	The best match is defined as:
+//	- A match is better if it’s matching pattern type is better.
+//	  * Exact match > suffix match > prefix match > universal match.
+//
+//	- If two matches are of the same pattern type, the longer match is
+//	  better.
+//	  * This is to compare the length of the matching pattern, e.g. “*ABCDE” >
+//	    “*ABC”
+func FindBestMatchingVirtualHost(host string, vHosts []*VirtualHost) *VirtualHost { // Maybe move this crap to client
+	var (
+		matchVh   *VirtualHost
+		matchType = domainMatchTypeInvalid
+		matchLen  int
+	)
+	for _, vh := range vHosts {
+		for _, domain := range vh.Domains {
+			typ, matched := match(domain, host)
+			if typ == domainMatchTypeInvalid {
+				// The rds response is invalid.
+				return nil
+			}
+			if matchType.betterThan(typ) || matchType == typ && matchLen >= len(domain) || !matched {
+				// The previous match has better type, or the previous match has
+				// better length, or this domain isn't a match.
+				continue
+			}
+			matchVh = vh
+			matchType = typ
+			matchLen = len(domain)
+		}
+	}
+	return matchVh
+}
+
+// FindBestMatchingVirtualHostServer returns the virtual host whose domains field best
+// matches authority.
+func FindBestMatchingVirtualHostServer(authority string, vHosts []VirtualHostWithInterceptors) *VirtualHostWithInterceptors {
+	var (
+		matchVh   *VirtualHostWithInterceptors
+		matchType = domainMatchTypeInvalid
+		matchLen  int
+	)
+	for _, vh := range vHosts {
+		for _, domain := range vh.Domains {
+			typ, matched := match(domain, authority)
+			if typ == domainMatchTypeInvalid {
+				// The rds response is invalid.
+				return nil
+			}
+			if matchType.betterThan(typ) || matchType == typ && matchLen >= len(domain) || !matched {
+				// The previous match has better type, or the previous match has
+				// better length, or this domain isn't a match.
+				continue
+			}
+			matchVh = &vh
+			matchType = typ
+			matchLen = len(domain)
+		}
+	}
+	return matchVh
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/matcher/matcher_header.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/matcher/matcher_header.go
@@ -1,0 +1,274 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package matcher
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"google.golang.org/grpc/internal/grpcutil"
+	"google.golang.org/grpc/metadata"
+)
+
+// HeaderMatcher is an interface for header matchers. These are
+// documented in (EnvoyProxy link here?). These matchers will match on different
+// aspects of HTTP header name/value pairs.
+type HeaderMatcher interface {
+	Match(metadata.MD) bool
+	String() string
+}
+
+// valueFromMD retrieves metadata from context. If there are
+// multiple values, the values are concatenated with "," (comma and no space).
+//
+// All header matchers only match against the comma-concatenated string.
+func valueFromMD(md metadata.MD, key string) (string, bool) {
+	vs, ok := md[key]
+	if !ok {
+		return "", false
+	}
+	return strings.Join(vs, ","), true
+}
+
+// HeaderExactMatcher matches on an exact match of the value of the header.
+type HeaderExactMatcher struct {
+	key    string
+	exact  string
+	invert bool
+}
+
+// NewHeaderExactMatcher returns a new HeaderExactMatcher.
+func NewHeaderExactMatcher(key, exact string, invert bool) *HeaderExactMatcher {
+	return &HeaderExactMatcher{key: key, exact: exact, invert: invert}
+}
+
+// Match returns whether the passed in HTTP Headers match according to the
+// HeaderExactMatcher.
+func (hem *HeaderExactMatcher) Match(md metadata.MD) bool {
+	v, ok := valueFromMD(md, hem.key)
+	if !ok {
+		return false
+	}
+	return (v == hem.exact) != hem.invert
+}
+
+func (hem *HeaderExactMatcher) String() string {
+	return fmt.Sprintf("headerExact:%v:%v", hem.key, hem.exact)
+}
+
+// HeaderRegexMatcher matches on whether the entire request header value matches
+// the regex.
+type HeaderRegexMatcher struct {
+	key    string
+	re     *regexp.Regexp
+	invert bool
+}
+
+// NewHeaderRegexMatcher returns a new HeaderRegexMatcher.
+func NewHeaderRegexMatcher(key string, re *regexp.Regexp, invert bool) *HeaderRegexMatcher {
+	return &HeaderRegexMatcher{key: key, re: re, invert: invert}
+}
+
+// Match returns whether the passed in HTTP Headers match according to the
+// HeaderRegexMatcher.
+func (hrm *HeaderRegexMatcher) Match(md metadata.MD) bool {
+	v, ok := valueFromMD(md, hrm.key)
+	if !ok {
+		return false
+	}
+	return grpcutil.FullMatchWithRegex(hrm.re, v) != hrm.invert
+}
+
+func (hrm *HeaderRegexMatcher) String() string {
+	return fmt.Sprintf("headerRegex:%v:%v", hrm.key, hrm.re.String())
+}
+
+// HeaderRangeMatcher matches on whether the request header value is within the
+// range. The header value must be an integer in base 10 notation.
+type HeaderRangeMatcher struct {
+	key        string
+	start, end int64 // represents [start, end).
+	invert     bool
+}
+
+// NewHeaderRangeMatcher returns a new HeaderRangeMatcher.
+func NewHeaderRangeMatcher(key string, start, end int64, invert bool) *HeaderRangeMatcher {
+	return &HeaderRangeMatcher{key: key, start: start, end: end, invert: invert}
+}
+
+// Match returns whether the passed in HTTP Headers match according to the
+// HeaderRangeMatcher.
+func (hrm *HeaderRangeMatcher) Match(md metadata.MD) bool {
+	v, ok := valueFromMD(md, hrm.key)
+	if !ok {
+		return false
+	}
+	if i, err := strconv.ParseInt(v, 10, 64); err == nil && i >= hrm.start && i < hrm.end {
+		return !hrm.invert
+	}
+	return hrm.invert
+}
+
+func (hrm *HeaderRangeMatcher) String() string {
+	return fmt.Sprintf("headerRange:%v:[%d,%d)", hrm.key, hrm.start, hrm.end)
+}
+
+// HeaderPresentMatcher will match based on whether the header is present in the
+// whole request.
+type HeaderPresentMatcher struct {
+	key     string
+	present bool
+}
+
+// NewHeaderPresentMatcher returns a new HeaderPresentMatcher.
+func NewHeaderPresentMatcher(key string, present bool, invert bool) *HeaderPresentMatcher {
+	if invert {
+		present = !present
+	}
+	return &HeaderPresentMatcher{key: key, present: present}
+}
+
+// Match returns whether the passed in HTTP Headers match according to the
+// HeaderPresentMatcher.
+func (hpm *HeaderPresentMatcher) Match(md metadata.MD) bool {
+	vs, ok := valueFromMD(md, hpm.key)
+	present := ok && len(vs) > 0 // TODO: Are we sure we need this len(vs) > 0?
+	return present == hpm.present
+}
+
+func (hpm *HeaderPresentMatcher) String() string {
+	return fmt.Sprintf("headerPresent:%v:%v", hpm.key, hpm.present)
+}
+
+// HeaderPrefixMatcher matches on whether the prefix of the header value matches
+// the prefix passed into this struct.
+type HeaderPrefixMatcher struct {
+	key    string
+	prefix string
+	invert bool
+}
+
+// NewHeaderPrefixMatcher returns a new HeaderPrefixMatcher.
+func NewHeaderPrefixMatcher(key string, prefix string, invert bool) *HeaderPrefixMatcher {
+	return &HeaderPrefixMatcher{key: key, prefix: prefix, invert: invert}
+}
+
+// Match returns whether the passed in HTTP Headers match according to the
+// HeaderPrefixMatcher.
+func (hpm *HeaderPrefixMatcher) Match(md metadata.MD) bool {
+	v, ok := valueFromMD(md, hpm.key)
+	if !ok {
+		return false
+	}
+	return strings.HasPrefix(v, hpm.prefix) != hpm.invert
+}
+
+func (hpm *HeaderPrefixMatcher) String() string {
+	return fmt.Sprintf("headerPrefix:%v:%v", hpm.key, hpm.prefix)
+}
+
+// HeaderSuffixMatcher matches on whether the suffix of the header value matches
+// the suffix passed into this struct.
+type HeaderSuffixMatcher struct {
+	key    string
+	suffix string
+	invert bool
+}
+
+// NewHeaderSuffixMatcher returns a new HeaderSuffixMatcher.
+func NewHeaderSuffixMatcher(key string, suffix string, invert bool) *HeaderSuffixMatcher {
+	return &HeaderSuffixMatcher{key: key, suffix: suffix, invert: invert}
+}
+
+// Match returns whether the passed in HTTP Headers match according to the
+// HeaderSuffixMatcher.
+func (hsm *HeaderSuffixMatcher) Match(md metadata.MD) bool {
+	v, ok := valueFromMD(md, hsm.key)
+	if !ok {
+		return false
+	}
+	return strings.HasSuffix(v, hsm.suffix) != hsm.invert
+}
+
+func (hsm *HeaderSuffixMatcher) String() string {
+	return fmt.Sprintf("headerSuffix:%v:%v", hsm.key, hsm.suffix)
+}
+
+// HeaderContainsMatcher matches on whether the header value contains the
+// value passed into this struct.
+type HeaderContainsMatcher struct {
+	key      string
+	contains string
+	invert   bool
+}
+
+// NewHeaderContainsMatcher returns a new HeaderContainsMatcher. key is the HTTP
+// Header key to match on, and contains is the value that the header should
+// contain for a successful match. An empty contains string does not
+// work, use HeaderPresentMatcher in that case.
+func NewHeaderContainsMatcher(key string, contains string, invert bool) *HeaderContainsMatcher {
+	return &HeaderContainsMatcher{key: key, contains: contains, invert: invert}
+}
+
+// Match returns whether the passed in HTTP Headers match according to the
+// HeaderContainsMatcher.
+func (hcm *HeaderContainsMatcher) Match(md metadata.MD) bool {
+	v, ok := valueFromMD(md, hcm.key)
+	if !ok {
+		return false
+	}
+	return strings.Contains(v, hcm.contains) != hcm.invert
+}
+
+func (hcm *HeaderContainsMatcher) String() string {
+	return fmt.Sprintf("headerContains:%v%v", hcm.key, hcm.contains)
+}
+
+// HeaderStringMatcher matches on whether the header value matches against the
+// StringMatcher specified.
+type HeaderStringMatcher struct {
+	key           string
+	stringMatcher StringMatcher
+	invert        bool
+}
+
+// NewHeaderStringMatcher returns a new HeaderStringMatcher.
+func NewHeaderStringMatcher(key string, sm StringMatcher, invert bool) *HeaderStringMatcher {
+	return &HeaderStringMatcher{
+		key:           key,
+		stringMatcher: sm,
+		invert:        invert,
+	}
+}
+
+// Match returns whether the passed in HTTP Headers match according to the
+// specified StringMatcher.
+func (hsm *HeaderStringMatcher) Match(md metadata.MD) bool {
+	v, ok := valueFromMD(md, hsm.key)
+	if !ok {
+		return false
+	}
+	return hsm.stringMatcher.Match(v) != hsm.invert
+}
+
+func (hsm *HeaderStringMatcher) String() string {
+	return fmt.Sprintf("headerString:%v:%v", hsm.key, hsm.stringMatcher)
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/matcher/matcher_header_test.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/matcher/matcher_header_test.go
@@ -1,0 +1,549 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package matcher
+
+import (
+	"regexp"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func TestHeaderExactMatcherMatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		key, exact string
+		md         metadata.MD
+		want       bool
+		invert     bool
+	}{
+		{
+			name:  "one value one match",
+			key:   "th",
+			exact: "tv",
+			md:    metadata.Pairs("th", "tv"),
+			want:  true,
+		},
+		{
+			name:  "two value one match",
+			key:   "th",
+			exact: "tv",
+			md:    metadata.Pairs("th", "abc", "th", "tv"),
+			// Doesn't match comma-concatenated string.
+			want: false,
+		},
+		{
+			name:  "two value match concatenated",
+			key:   "th",
+			exact: "abc,tv",
+			md:    metadata.Pairs("th", "abc", "th", "tv"),
+			want:  true,
+		},
+		{
+			name:  "not match",
+			key:   "th",
+			exact: "tv",
+			md:    metadata.Pairs("th", "abc"),
+			want:  false,
+		},
+		{
+			name:   "invert header not present",
+			key:    "th",
+			exact:  "tv",
+			md:     metadata.Pairs(":method", "GET"),
+			want:   false,
+			invert: true,
+		},
+		{
+			name:   "invert header match",
+			key:    "th",
+			exact:  "tv",
+			md:     metadata.Pairs("th", "tv"),
+			want:   false,
+			invert: true,
+		},
+		{
+			name:   "invert header not match",
+			key:    "th",
+			exact:  "tv",
+			md:     metadata.Pairs("th", "tvv"),
+			want:   true,
+			invert: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hem := NewHeaderExactMatcher(tt.key, tt.exact, tt.invert)
+			if got := hem.Match(tt.md); got != tt.want {
+				t.Errorf("match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeaderRegexMatcherMatch(t *testing.T) {
+	tests := []struct {
+		name          string
+		key, regexStr string
+		md            metadata.MD
+		want          bool
+		invert        bool
+	}{
+		{
+			name:     "one value one match",
+			key:      "th",
+			regexStr: "^t+v*$",
+			md:       metadata.Pairs("th", "tttvv"),
+			want:     true,
+		},
+		{
+			name:     "two value one match",
+			key:      "th",
+			regexStr: "^t+v*$",
+			md:       metadata.Pairs("th", "abc", "th", "tttvv"),
+			want:     false,
+		},
+		{
+			name:     "two value match concatenated",
+			key:      "th",
+			regexStr: "^[abc]*,t+v*$",
+			md:       metadata.Pairs("th", "abc", "th", "tttvv"),
+			want:     true,
+		},
+		{
+			name:     "no match",
+			key:      "th",
+			regexStr: "^t+v*$",
+			md:       metadata.Pairs("th", "abc"),
+			want:     false,
+		},
+		{
+			name:     "no match because only part of value matches with regex",
+			key:      "header",
+			regexStr: "^a+$",
+			md:       metadata.Pairs("header", "ab"),
+			want:     false,
+		},
+		{
+			name:     "match because full value matches with regex",
+			key:      "header",
+			regexStr: "^a+$",
+			md:       metadata.Pairs("header", "aa"),
+			want:     true,
+		},
+		{
+			name:     "invert header not present",
+			key:      "th",
+			regexStr: "^t+v*$",
+			md:       metadata.Pairs(":method", "GET"),
+			want:     false,
+			invert:   true,
+		},
+		{
+			name:     "invert header match",
+			key:      "th",
+			regexStr: "^t+v*$",
+			md:       metadata.Pairs("th", "tttvv"),
+			want:     false,
+			invert:   true,
+		},
+		{
+			name:     "invert header not match",
+			key:      "th",
+			regexStr: "^t+v*$",
+			md:       metadata.Pairs("th", "abc"),
+			want:     true,
+			invert:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hrm := NewHeaderRegexMatcher(tt.key, regexp.MustCompile(tt.regexStr), tt.invert)
+			if got := hrm.Match(tt.md); got != tt.want {
+				t.Errorf("match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeaderRangeMatcherMatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		key        string
+		start, end int64
+		md         metadata.MD
+		want       bool
+		invert     bool
+	}{
+		{
+			name:  "match",
+			key:   "th",
+			start: 1, end: 10,
+			md:   metadata.Pairs("th", "5"),
+			want: true,
+		},
+		{
+			name:  "equal to start",
+			key:   "th",
+			start: 1, end: 10,
+			md:   metadata.Pairs("th", "1"),
+			want: true,
+		},
+		{
+			name:  "equal to end",
+			key:   "th",
+			start: 1, end: 10,
+			md:   metadata.Pairs("th", "10"),
+			want: false,
+		},
+		{
+			name:  "negative",
+			key:   "th",
+			start: -10, end: 10,
+			md:   metadata.Pairs("th", "-5"),
+			want: true,
+		},
+		{
+			name:  "invert header not present",
+			key:   "th",
+			start: 1, end: 10,
+			md:     metadata.Pairs(":method", "GET"),
+			want:   false,
+			invert: true,
+		},
+		{
+			name:  "invert header match",
+			key:   "th",
+			start: 1, end: 10,
+			md:     metadata.Pairs("th", "5"),
+			want:   false,
+			invert: true,
+		},
+		{
+			name:  "invert header not match",
+			key:   "th",
+			start: 1, end: 9,
+			md:     metadata.Pairs("th", "10"),
+			want:   true,
+			invert: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hrm := NewHeaderRangeMatcher(tt.key, tt.start, tt.end, tt.invert)
+			if got := hrm.Match(tt.md); got != tt.want {
+				t.Errorf("match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeaderPresentMatcherMatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		present bool
+		md      metadata.MD
+		want    bool
+		invert  bool
+	}{
+		{
+			name:    "want present is present",
+			key:     "th",
+			present: true,
+			md:      metadata.Pairs("th", "tv"),
+			want:    true,
+		},
+		{
+			name:    "want present not present",
+			key:     "th",
+			present: true,
+			md:      metadata.Pairs("abc", "tv"),
+			want:    false,
+		},
+		{
+			name:    "want not present is present",
+			key:     "th",
+			present: false,
+			md:      metadata.Pairs("th", "tv"),
+			want:    false,
+		},
+		{
+			name:    "want not present is not present",
+			key:     "th",
+			present: false,
+			md:      metadata.Pairs("abc", "tv"),
+			want:    true,
+		},
+		{
+			name:    "invert header not present",
+			key:     "th",
+			present: true,
+			md:      metadata.Pairs(":method", "GET"),
+			want:    true,
+			invert:  true,
+		},
+		{
+			name:    "invert header match",
+			key:     "th",
+			present: true,
+			md:      metadata.Pairs("th", "tv"),
+			want:    false,
+			invert:  true,
+		},
+		{
+			name:    "invert header not match",
+			key:     "th",
+			present: true,
+			md:      metadata.Pairs(":method", "GET"),
+			want:    true,
+			invert:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hpm := NewHeaderPresentMatcher(tt.key, tt.present, tt.invert)
+			if got := hpm.Match(tt.md); got != tt.want {
+				t.Errorf("match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeaderPrefixMatcherMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		key, prefix string
+		md          metadata.MD
+		want        bool
+		invert      bool
+	}{
+		{
+			name:   "one value one match",
+			key:    "th",
+			prefix: "tv",
+			md:     metadata.Pairs("th", "tv123"),
+			want:   true,
+		},
+		{
+			name:   "two value one match",
+			key:    "th",
+			prefix: "tv",
+			md:     metadata.Pairs("th", "abc", "th", "tv123"),
+			want:   false,
+		},
+		{
+			name:   "two value match concatenated",
+			key:    "th",
+			prefix: "tv",
+			md:     metadata.Pairs("th", "tv123", "th", "abc"),
+			want:   true,
+		},
+		{
+			name:   "not match",
+			key:    "th",
+			prefix: "tv",
+			md:     metadata.Pairs("th", "abc"),
+			want:   false,
+		},
+		{
+			name:   "invert header not present",
+			key:    "th",
+			prefix: "tv",
+			md:     metadata.Pairs(":method", "GET"),
+			want:   false,
+			invert: true,
+		},
+		{
+			name:   "invert header match",
+			key:    "th",
+			prefix: "tv",
+			md:     metadata.Pairs("th", "tv123"),
+			want:   false,
+			invert: true,
+		},
+		{
+			name:   "invert header not match",
+			key:    "th",
+			prefix: "tv",
+			md:     metadata.Pairs("th", "abc"),
+			want:   true,
+			invert: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hpm := NewHeaderPrefixMatcher(tt.key, tt.prefix, tt.invert)
+			if got := hpm.Match(tt.md); got != tt.want {
+				t.Errorf("match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeaderSuffixMatcherMatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		key, suffix string
+		md          metadata.MD
+		want        bool
+		invert      bool
+	}{
+		{
+			name:   "one value one match",
+			key:    "th",
+			suffix: "tv",
+			md:     metadata.Pairs("th", "123tv"),
+			want:   true,
+		},
+		{
+			name:   "two value one match",
+			key:    "th",
+			suffix: "tv",
+			md:     metadata.Pairs("th", "123tv", "th", "abc"),
+			want:   false,
+		},
+		{
+			name:   "two value match concatenated",
+			key:    "th",
+			suffix: "tv",
+			md:     metadata.Pairs("th", "abc", "th", "123tv"),
+			want:   true,
+		},
+		{
+			name:   "not match",
+			key:    "th",
+			suffix: "tv",
+			md:     metadata.Pairs("th", "abc"),
+			want:   false,
+		},
+		{
+			name:   "invert header not present",
+			key:    "th",
+			suffix: "tv",
+			md:     metadata.Pairs(":method", "GET"),
+			want:   false,
+			invert: true,
+		},
+		{
+			name:   "invert header match",
+			key:    "th",
+			suffix: "tv",
+			md:     metadata.Pairs("th", "123tv"),
+			want:   false,
+			invert: true,
+		},
+		{
+			name:   "invert header not match",
+			key:    "th",
+			suffix: "tv",
+			md:     metadata.Pairs("th", "abc"),
+			want:   true,
+			invert: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hsm := NewHeaderSuffixMatcher(tt.key, tt.suffix, tt.invert)
+			if got := hsm.Match(tt.md); got != tt.want {
+				t.Errorf("match() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHeaderStringMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		key    string
+		sm     StringMatcher
+		invert bool
+		md     metadata.MD
+		want   bool
+	}{
+		{
+			name: "should-match",
+			key:  "th",
+			sm: StringMatcher{
+				exactMatch: newStringP("tv"),
+			},
+			invert: false,
+			md:     metadata.Pairs("th", "tv"),
+			want:   true,
+		},
+		{
+			name: "not match",
+			key:  "th",
+			sm: StringMatcher{
+				containsMatch: newStringP("tv"),
+			},
+			invert: false,
+			md:     metadata.Pairs("th", "not-match"),
+			want:   false,
+		},
+		{
+			name: "invert string match",
+			key:  "th",
+			sm: StringMatcher{
+				containsMatch: newStringP("tv"),
+			},
+			invert: true,
+			md:     metadata.Pairs("th", "not-match"),
+			want:   true,
+		},
+		{
+			name: "header missing",
+			key:  "th",
+			sm: StringMatcher{
+				containsMatch: newStringP("tv"),
+			},
+			invert: false,
+			md:     metadata.Pairs("not-specified-key", "not-match"),
+			want:   false,
+		},
+		{
+			name: "header missing invert true",
+			key:  "th",
+			sm: StringMatcher{
+				containsMatch: newStringP("tv"),
+			},
+			invert: true,
+			md:     metadata.Pairs("not-specified-key", "not-match"),
+			want:   false,
+		},
+		{
+			name: "header empty string invert",
+			key:  "th",
+			sm: StringMatcher{
+				containsMatch: newStringP("tv"),
+			},
+			invert: true,
+			md:     metadata.Pairs("th", ""),
+			want:   true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hsm := NewHeaderStringMatcher(test.key, test.sm, test.invert)
+			if got := hsm.Match(test.md); got != test.want {
+				t.Errorf("match() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/matcher/string_matcher.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/matcher/string_matcher.go
@@ -1,0 +1,185 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package matcher contains types that need to be shared between code under
+// google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils...
+// and the rest of xDS client internal code.
+package matcher
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	v3matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"google.golang.org/grpc/internal/grpcutil"
+)
+
+// StringMatcher contains match criteria for matching a string, and is an
+// internal representation of the `StringMatcher` proto defined at
+// https://github.com/envoyproxy/envoy/blob/main/api/envoy/type/matcher/v3/string.proto.
+type StringMatcher struct {
+	// Since these match fields are part of a `oneof` in the corresponding xDS
+	// proto, only one of them is expected to be set.
+	exactMatch    *string
+	prefixMatch   *string
+	suffixMatch   *string
+	regexMatch    *regexp.Regexp
+	containsMatch *string
+	// If true, indicates the exact/prefix/suffix/contains matching should be
+	// case insensitive. This has no effect on the regex match.
+	ignoreCase bool
+}
+
+// Match returns true if input matches the criteria in the given StringMatcher.
+func (sm StringMatcher) Match(input string) bool {
+	if sm.ignoreCase {
+		input = strings.ToLower(input)
+	}
+	switch {
+	case sm.exactMatch != nil:
+		return input == *sm.exactMatch
+	case sm.prefixMatch != nil:
+		return strings.HasPrefix(input, *sm.prefixMatch)
+	case sm.suffixMatch != nil:
+		return strings.HasSuffix(input, *sm.suffixMatch)
+	case sm.regexMatch != nil:
+		return grpcutil.FullMatchWithRegex(sm.regexMatch, input)
+	case sm.containsMatch != nil:
+		return strings.Contains(input, *sm.containsMatch)
+	}
+	return false
+}
+
+// StringMatcherFromProto is a helper function to create a StringMatcher from
+// the corresponding StringMatcher proto.
+//
+// Returns a non-nil error if matcherProto is invalid.
+func StringMatcherFromProto(matcherProto *v3matcherpb.StringMatcher) (StringMatcher, error) {
+	if matcherProto == nil {
+		return StringMatcher{}, errors.New("input StringMatcher proto is nil")
+	}
+
+	matcher := StringMatcher{ignoreCase: matcherProto.GetIgnoreCase()}
+	switch mt := matcherProto.GetMatchPattern().(type) {
+	case *v3matcherpb.StringMatcher_Exact:
+		matcher.exactMatch = &mt.Exact
+		if matcher.ignoreCase {
+			*matcher.exactMatch = strings.ToLower(*matcher.exactMatch)
+		}
+	case *v3matcherpb.StringMatcher_Prefix:
+		if matcherProto.GetPrefix() == "" {
+			return StringMatcher{}, errors.New("empty prefix is not allowed in StringMatcher")
+		}
+		matcher.prefixMatch = &mt.Prefix
+		if matcher.ignoreCase {
+			*matcher.prefixMatch = strings.ToLower(*matcher.prefixMatch)
+		}
+	case *v3matcherpb.StringMatcher_Suffix:
+		if matcherProto.GetSuffix() == "" {
+			return StringMatcher{}, errors.New("empty suffix is not allowed in StringMatcher")
+		}
+		matcher.suffixMatch = &mt.Suffix
+		if matcher.ignoreCase {
+			*matcher.suffixMatch = strings.ToLower(*matcher.suffixMatch)
+		}
+	case *v3matcherpb.StringMatcher_SafeRegex:
+		regex := matcherProto.GetSafeRegex().GetRegex()
+		re, err := regexp.Compile(regex)
+		if err != nil {
+			return StringMatcher{}, fmt.Errorf("safe_regex matcher %q is invalid", regex)
+		}
+		matcher.regexMatch = re
+	case *v3matcherpb.StringMatcher_Contains:
+		if matcherProto.GetContains() == "" {
+			return StringMatcher{}, errors.New("empty contains is not allowed in StringMatcher")
+		}
+		matcher.containsMatch = &mt.Contains
+		if matcher.ignoreCase {
+			*matcher.containsMatch = strings.ToLower(*matcher.containsMatch)
+		}
+	default:
+		return StringMatcher{}, fmt.Errorf("unrecognized string matcher: %+v", matcherProto)
+	}
+	return matcher, nil
+}
+
+// StringMatcherForTesting is a helper function to create a StringMatcher based
+// on the given arguments. Intended only for testing purposes.
+func StringMatcherForTesting(exact, prefix, suffix, contains *string, regex *regexp.Regexp, ignoreCase bool) StringMatcher {
+	sm := StringMatcher{
+		exactMatch:    exact,
+		prefixMatch:   prefix,
+		suffixMatch:   suffix,
+		regexMatch:    regex,
+		containsMatch: contains,
+		ignoreCase:    ignoreCase,
+	}
+	if ignoreCase {
+		switch {
+		case sm.exactMatch != nil:
+			*sm.exactMatch = strings.ToLower(*exact)
+		case sm.prefixMatch != nil:
+			*sm.prefixMatch = strings.ToLower(*prefix)
+		case sm.suffixMatch != nil:
+			*sm.suffixMatch = strings.ToLower(*suffix)
+		case sm.containsMatch != nil:
+			*sm.containsMatch = strings.ToLower(*contains)
+		}
+	}
+	return sm
+}
+
+// ExactMatch returns the value of the configured exact match or an empty string
+// if exact match criteria was not specified.
+func (sm StringMatcher) ExactMatch() string {
+	if sm.exactMatch != nil {
+		return *sm.exactMatch
+	}
+	return ""
+}
+
+// Equal returns true if other and sm are equivalent to each other.
+func (sm StringMatcher) Equal(other StringMatcher) bool {
+	if sm.ignoreCase != other.ignoreCase {
+		return false
+	}
+
+	if (sm.exactMatch != nil) != (other.exactMatch != nil) ||
+		(sm.prefixMatch != nil) != (other.prefixMatch != nil) ||
+		(sm.suffixMatch != nil) != (other.suffixMatch != nil) ||
+		(sm.regexMatch != nil) != (other.regexMatch != nil) ||
+		(sm.containsMatch != nil) != (other.containsMatch != nil) {
+		return false
+	}
+
+	switch {
+	case sm.exactMatch != nil:
+		return *sm.exactMatch == *other.exactMatch
+	case sm.prefixMatch != nil:
+		return *sm.prefixMatch == *other.prefixMatch
+	case sm.suffixMatch != nil:
+		return *sm.suffixMatch == *other.suffixMatch
+	case sm.regexMatch != nil:
+		return sm.regexMatch.String() == other.regexMatch.String()
+	case sm.containsMatch != nil:
+		return *sm.containsMatch == *other.containsMatch
+	}
+	return true
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/matcher/string_matcher_test.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/matcher/string_matcher_test.go
@@ -1,0 +1,315 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package matcher
+
+import (
+	"regexp"
+	"testing"
+
+	v3matcherpb "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStringMatcherFromProto(t *testing.T) {
+	tests := []struct {
+		desc        string
+		inputProto  *v3matcherpb.StringMatcher
+		wantMatcher StringMatcher
+		wantErr     bool
+	}{
+		{
+			desc:    "nil proto",
+			wantErr: true,
+		},
+		{
+			desc: "empty prefix",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Prefix{Prefix: ""},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "empty suffix",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Suffix{Suffix: ""},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "empty contains",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Contains{Contains: ""},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "invalid regex",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{
+					SafeRegex: &v3matcherpb.RegexMatcher{Regex: "??"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			desc: "happy case exact",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "exact"},
+			},
+			wantMatcher: StringMatcher{exactMatch: newStringP("exact")},
+		},
+		{
+			desc: "happy case exact ignore case",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "EXACT"},
+				IgnoreCase:   true,
+			},
+			wantMatcher: StringMatcher{
+				exactMatch: newStringP("exact"),
+				ignoreCase: true,
+			},
+		},
+		{
+			desc: "happy case prefix",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Prefix{Prefix: "prefix"},
+			},
+			wantMatcher: StringMatcher{prefixMatch: newStringP("prefix")},
+		},
+		{
+			desc: "happy case prefix ignore case",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Prefix{Prefix: "PREFIX"},
+				IgnoreCase:   true,
+			},
+			wantMatcher: StringMatcher{
+				prefixMatch: newStringP("prefix"),
+				ignoreCase:  true,
+			},
+		},
+		{
+			desc: "happy case suffix",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Suffix{Suffix: "suffix"},
+			},
+			wantMatcher: StringMatcher{suffixMatch: newStringP("suffix")},
+		},
+		{
+			desc: "happy case suffix ignore case",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Suffix{Suffix: "SUFFIX"},
+				IgnoreCase:   true,
+			},
+			wantMatcher: StringMatcher{
+				suffixMatch: newStringP("suffix"),
+				ignoreCase:  true,
+			},
+		},
+		{
+			desc: "happy case regex",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{
+					SafeRegex: &v3matcherpb.RegexMatcher{Regex: "good?regex?"},
+				},
+			},
+			wantMatcher: StringMatcher{regexMatch: regexp.MustCompile("good?regex?")},
+		},
+		{
+			desc: "happy case contains",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Contains{Contains: "contains"},
+			},
+			wantMatcher: StringMatcher{containsMatch: newStringP("contains")},
+		},
+		{
+			desc: "happy case contains ignore case",
+			inputProto: &v3matcherpb.StringMatcher{
+				MatchPattern: &v3matcherpb.StringMatcher_Contains{Contains: "CONTAINS"},
+				IgnoreCase:   true,
+			},
+			wantMatcher: StringMatcher{
+				containsMatch: newStringP("contains"),
+				ignoreCase:    true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			gotMatcher, err := StringMatcherFromProto(test.inputProto)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("StringMatcherFromProto(%+v) returned err: %v, wantErr: %v", test.inputProto, err, test.wantErr)
+			}
+			if diff := cmp.Diff(gotMatcher, test.wantMatcher, cmp.AllowUnexported(regexp.Regexp{})); diff != "" {
+				t.Fatalf("StringMatcherFromProto(%+v) returned unexpected diff (-got, +want):\n%s", test.inputProto, diff)
+			}
+		})
+	}
+}
+
+func TestMatch(t *testing.T) {
+	var (
+		exactMatcher, _           = StringMatcherFromProto(&v3matcherpb.StringMatcher{MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "exact"}})
+		prefixMatcher, _          = StringMatcherFromProto(&v3matcherpb.StringMatcher{MatchPattern: &v3matcherpb.StringMatcher_Prefix{Prefix: "prefix"}})
+		suffixMatcher, _          = StringMatcherFromProto(&v3matcherpb.StringMatcher{MatchPattern: &v3matcherpb.StringMatcher_Suffix{Suffix: "suffix"}})
+		regexMatcher, _           = StringMatcherFromProto(&v3matcherpb.StringMatcher{MatchPattern: &v3matcherpb.StringMatcher_SafeRegex{SafeRegex: &v3matcherpb.RegexMatcher{Regex: "good?regex?"}}})
+		containsMatcher, _        = StringMatcherFromProto(&v3matcherpb.StringMatcher{MatchPattern: &v3matcherpb.StringMatcher_Contains{Contains: "contains"}})
+		exactMatcherIgnoreCase, _ = StringMatcherFromProto(&v3matcherpb.StringMatcher{
+			MatchPattern: &v3matcherpb.StringMatcher_Exact{Exact: "exact"},
+			IgnoreCase:   true,
+		})
+		prefixMatcherIgnoreCase, _ = StringMatcherFromProto(&v3matcherpb.StringMatcher{
+			MatchPattern: &v3matcherpb.StringMatcher_Prefix{Prefix: "prefix"},
+			IgnoreCase:   true,
+		})
+		suffixMatcherIgnoreCase, _ = StringMatcherFromProto(&v3matcherpb.StringMatcher{
+			MatchPattern: &v3matcherpb.StringMatcher_Suffix{Suffix: "suffix"},
+			IgnoreCase:   true,
+		})
+		containsMatcherIgnoreCase, _ = StringMatcherFromProto(&v3matcherpb.StringMatcher{
+			MatchPattern: &v3matcherpb.StringMatcher_Contains{Contains: "contains"},
+			IgnoreCase:   true,
+		})
+	)
+
+	tests := []struct {
+		desc      string
+		matcher   StringMatcher
+		input     string
+		wantMatch bool
+	}{
+		{
+			desc:      "exact match success",
+			matcher:   exactMatcher,
+			input:     "exact",
+			wantMatch: true,
+		},
+		{
+			desc:    "exact match failure",
+			matcher: exactMatcher,
+			input:   "not-exact",
+		},
+		{
+			desc:      "exact match success with ignore case",
+			matcher:   exactMatcherIgnoreCase,
+			input:     "EXACT",
+			wantMatch: true,
+		},
+		{
+			desc:    "exact match failure with ignore case",
+			matcher: exactMatcherIgnoreCase,
+			input:   "not-exact",
+		},
+		{
+			desc:      "prefix match success",
+			matcher:   prefixMatcher,
+			input:     "prefixIsHere",
+			wantMatch: true,
+		},
+		{
+			desc:    "prefix match failure",
+			matcher: prefixMatcher,
+			input:   "not-prefix",
+		},
+		{
+			desc:      "prefix match success with ignore case",
+			matcher:   prefixMatcherIgnoreCase,
+			input:     "PREFIXisHere",
+			wantMatch: true,
+		},
+		{
+			desc:    "prefix match failure with ignore case",
+			matcher: prefixMatcherIgnoreCase,
+			input:   "not-PREFIX",
+		},
+		{
+			desc:      "suffix match success",
+			matcher:   suffixMatcher,
+			input:     "hereIsThesuffix",
+			wantMatch: true,
+		},
+		{
+			desc:    "suffix match failure",
+			matcher: suffixMatcher,
+			input:   "suffix-is-not-here",
+		},
+		{
+			desc:      "suffix match success with ignore case",
+			matcher:   suffixMatcherIgnoreCase,
+			input:     "hereIsTheSuFFix",
+			wantMatch: true,
+		},
+		{
+			desc:    "suffix match failure with ignore case",
+			matcher: suffixMatcherIgnoreCase,
+			input:   "SUFFIX-is-not-here",
+		},
+		{
+			desc:      "regex match success",
+			matcher:   regexMatcher,
+			input:     "goodregex",
+			wantMatch: true,
+		},
+		{
+			desc:      "regex match failure because only part match",
+			matcher:   regexMatcher,
+			input:     "goodregexa",
+			wantMatch: false,
+		},
+		{
+			desc:    "regex match failure",
+			matcher: regexMatcher,
+			input:   "regex-is-not-here",
+		},
+		{
+			desc:      "contains match success",
+			matcher:   containsMatcher,
+			input:     "IScontainsHERE",
+			wantMatch: true,
+		},
+		{
+			desc:    "contains match failure",
+			matcher: containsMatcher,
+			input:   "con-tains-is-not-here",
+		},
+		{
+			desc:      "contains match success with ignore case",
+			matcher:   containsMatcherIgnoreCase,
+			input:     "isCONTAINShere",
+			wantMatch: true,
+		},
+		{
+			desc:    "contains match failure with ignore case",
+			matcher: containsMatcherIgnoreCase,
+			input:   "CON-TAINS-is-not-here",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			if gotMatch := test.matcher.Match(test.input); gotMatch != test.wantMatch {
+				t.Errorf("StringMatcher.Match(%s) returned %v, want %v", test.input, gotMatch, test.wantMatch)
+			}
+		})
+	}
+}
+
+func newStringP(s string) *string {
+	return &s
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/matcher_path.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/matcher_path.go
@@ -1,0 +1,103 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"regexp"
+	"strings"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/clientutils"
+)
+
+type pathMatcher interface {
+	match(path string) bool
+	String() string
+}
+
+type pathExactMatcher struct {
+	// fullPath is all upper case if caseInsensitive is true.
+	fullPath        string
+	caseInsensitive bool
+}
+
+func newPathExactMatcher(p string, caseInsensitive bool) *pathExactMatcher {
+	ret := &pathExactMatcher{
+		fullPath:        p,
+		caseInsensitive: caseInsensitive,
+	}
+	if caseInsensitive {
+		ret.fullPath = strings.ToUpper(p)
+	}
+	return ret
+}
+
+func (pem *pathExactMatcher) match(path string) bool {
+	if pem.caseInsensitive {
+		return pem.fullPath == strings.ToUpper(path)
+	}
+	return pem.fullPath == path
+}
+
+func (pem *pathExactMatcher) String() string {
+	return "pathExact:" + pem.fullPath
+}
+
+type pathPrefixMatcher struct {
+	// prefix is all upper case if caseInsensitive is true.
+	prefix          string
+	caseInsensitive bool
+}
+
+func newPathPrefixMatcher(p string, caseInsensitive bool) *pathPrefixMatcher {
+	ret := &pathPrefixMatcher{
+		prefix:          p,
+		caseInsensitive: caseInsensitive,
+	}
+	if caseInsensitive {
+		ret.prefix = strings.ToUpper(p)
+	}
+	return ret
+}
+
+func (ppm *pathPrefixMatcher) match(path string) bool {
+	if ppm.caseInsensitive {
+		return strings.HasPrefix(strings.ToUpper(path), ppm.prefix)
+	}
+	return strings.HasPrefix(path, ppm.prefix)
+}
+
+func (ppm *pathPrefixMatcher) String() string {
+	return "pathPrefix:" + ppm.prefix
+}
+
+type pathRegexMatcher struct {
+	re *regexp.Regexp
+}
+
+func newPathRegexMatcher(re *regexp.Regexp) *pathRegexMatcher {
+	return &pathRegexMatcher{re: re}
+}
+
+func (prm *pathRegexMatcher) match(path string) bool {
+	return clientutils.FullMatchWithRegex(prm.re, path)
+}
+
+func (prm *pathRegexMatcher) String() string {
+	return "pathRegex:" + prm.re.String()
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/resolver/interceptor.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/resolver/interceptor.go
@@ -1,0 +1,57 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package resolver provides resolver-related functionality for xDS client
+// testing.
+package resolver
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// RPCInfo contains RPC information needed by a ConfigSelector.
+type RPCInfo struct {
+	// Context is the user's context for the RPC and contains headers and
+	// application timeout.  It is passed for interception purposes and for
+	// efficiency reasons.  SelectConfig should not be blocking.
+	Context context.Context
+	Method  string // i.e. "/Service/Method"
+}
+
+// ClientInterceptor is an interceptor for gRPC client streams.
+type ClientInterceptor interface {
+	// NewStream produces a ClientStream for an RPC which may optionally use
+	// the provided function to produce a stream for delegation.  Note:
+	// RPCInfo.Context should not be used (will be nil).
+	//
+	// done is invoked when the RPC is finished using its connection, or could
+	// not be assigned a connection.  RPC operations may still occur on
+	// ClientStream after done is called, since the interceptor is invoked by
+	// application-layer operations.  done must never be nil when called.
+	NewStream(ctx context.Context, ri RPCInfo, done func(), newStream func(ctx context.Context, done func()) (grpc.ClientStream, error)) (grpc.ClientStream, error)
+}
+
+// ServerInterceptor is an interceptor for incoming RPC's on gRPC server side.
+type ServerInterceptor interface {
+	// AllowRPC checks if an incoming RPC is allowed to proceed based on
+	// information about connection RPC was received on, and HTTP Headers. This
+	// information will be piped into context.
+	AllowRPC(ctx context.Context) error // TODO: Make this a real interceptor for filters such as rate limiting.
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/resource_type.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/resource_type.go
@@ -1,0 +1,35 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package testutils implements the xDS data model layer.
+//
+// Provides resource-type specific functionality to unmarshal xDS protos into
+// internal data structures for end2end testing of xDS client.
+package testutils
+
+import (
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/xdsresource"
+)
+
+// ResourceTypeMapForTesting maps TypeUrl to corresponding ResourceType.
+var ResourceTypeMapForTesting map[string]any
+
+func init() {
+	ResourceTypeMapForTesting = make(map[string]any)
+	ResourceTypeMapForTesting[xdsresource.V3ListenerURL] = listenerType
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/type.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/type.go
@@ -1,0 +1,119 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"time"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/xdsresource"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// UpdateValidatorFunc performs validations on update structs using
+// context/logic available at the xdsClient layer. Since these validation are
+// performed on internal update structs, they can be shared between different
+// API clients.
+type UpdateValidatorFunc func(any) error
+
+// UpdateMetadata contains the metadata for each update, including timestamp,
+// raw message, and so on.
+type UpdateMetadata struct {
+	// Status is the status of this resource, e.g. ACKed, NACKed, or
+	// Not_exist(removed).
+	Status ServiceStatus
+	// Version is the version of the xds response. Note that this is the version
+	// of the resource in use (previous ACKed). If a response is NACKed, the
+	// NACKed version is in ErrState.
+	Version string
+	// Timestamp is when the response is received.
+	Timestamp time.Time
+	// ErrState is set when the update is NACKed.
+	ErrState *UpdateErrorMetadata
+}
+
+// IsListenerResource returns true if the provider URL corresponds to an xDS
+// Listener resource.
+func IsListenerResource(url string) bool {
+	return url == xdsresource.V3ListenerURL
+}
+
+// IsHTTPConnManagerResource returns true if the provider URL corresponds to an xDS
+// HTTPConnManager resource.
+func IsHTTPConnManagerResource(url string) bool {
+	return url == xdsresource.V3HTTPConnManagerURL
+}
+
+// IsRouteConfigResource returns true if the provider URL corresponds to an xDS
+// RouteConfig resource.
+func IsRouteConfigResource(url string) bool {
+	return url == xdsresource.V3RouteConfigURL
+}
+
+// IsClusterResource returns true if the provider URL corresponds to an xDS
+// Cluster resource.
+func IsClusterResource(url string) bool {
+	return url == xdsresource.V3ClusterURL
+}
+
+// IsEndpointsResource returns true if the provider URL corresponds to an xDS
+// Endpoints resource.
+func IsEndpointsResource(url string) bool {
+	return url == xdsresource.V3EndpointsURL
+}
+
+// ServiceStatus is the status of the update.
+type ServiceStatus int
+
+const (
+	// ServiceStatusUnknown is the default state, before a watch is started for
+	// the resource.
+	ServiceStatusUnknown ServiceStatus = iota
+	// ServiceStatusRequested is when the watch is started, but before and
+	// response is received.
+	ServiceStatusRequested
+	// ServiceStatusNotExist is when the resource doesn't exist in
+	// state-of-the-world responses (e.g. LDS and CDS), which means the resource
+	// is removed by the management server.
+	ServiceStatusNotExist // Resource is removed in the server, in LDS/CDS.
+	// ServiceStatusACKed is when the resource is ACKed.
+	ServiceStatusACKed
+	// ServiceStatusNACKed is when the resource is NACKed.
+	ServiceStatusNACKed
+)
+
+// UpdateErrorMetadata is part of UpdateMetadata. It contains the error state
+// when a response is NACKed.
+type UpdateErrorMetadata struct {
+	// Version is the version of the NACKed response.
+	Version string
+	// Err contains why the response was NACKed.
+	Err error
+	// Timestamp is when the NACKed response was received.
+	Timestamp time.Time
+}
+
+// UpdateWithMD contains the raw message of the update and the metadata,
+// including version, raw message, timestamp.
+//
+// This is to be used for config dump and CSDS, not directly by users (like
+// resolvers/balancers).
+type UpdateWithMD struct {
+	MD  UpdateMetadata
+	Raw *anypb.Any
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/type_cds.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/type_cds.go
@@ -1,0 +1,157 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"encoding/json"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/matcher"
+)
+
+// ClusterType is the type of cluster from a received CDS response.
+type ClusterType int
+
+const (
+	// ClusterTypeEDS represents the EDS cluster type, which will delegate endpoint
+	// discovery to the management server.
+	ClusterTypeEDS ClusterType = iota
+	// ClusterTypeLogicalDNS represents the Logical DNS cluster type, which essentially
+	// maps to the gRPC behavior of using the DNS resolver with pick_first LB policy.
+	ClusterTypeLogicalDNS
+	// ClusterTypeAggregate represents the Aggregate Cluster type, which provides a
+	// prioritized list of clusters to use. It is used for failover between clusters
+	// with a different configuration.
+	ClusterTypeAggregate
+)
+
+// ClusterUpdate contains information from a received CDS response, which is of
+// interest to the registered CDS watcher.
+type ClusterUpdate struct {
+	ClusterType ClusterType
+	// ClusterName is the clusterName being watched for through CDS.
+	ClusterName string
+	// EDSServiceName is an optional name for EDS. If it's not set, the balancer
+	// should watch ClusterName for the EDS resources.
+	EDSServiceName string
+	// LRSServerConfig contains configuration about the xDS server that sent
+	// this cluster resource. This is also the server where load reports are to
+	// be sent, for this cluster.
+	LRSServerConfig *xdsclient.ServerConfig
+	// SecurityCfg contains security configuration sent by the control plane.
+	SecurityCfg *SecurityConfig
+	// MaxRequests for circuit breaking, if any (otherwise nil).
+	MaxRequests *uint32
+	// DNSHostName is used only for cluster type DNS. It's the DNS name to
+	// resolve in "host:port" form
+	DNSHostName string
+	// PrioritizedClusterNames is used only for cluster type aggregate. It represents
+	// a prioritized list of cluster names.
+	PrioritizedClusterNames []string
+
+	// LBPolicy represents the locality and endpoint picking policy in JSON,
+	// which will be the child policy of xds_cluster_impl.
+	LBPolicy json.RawMessage
+
+	// OutlierDetection is the outlier detection configuration for this cluster.
+	// If nil, it means this cluster does not use the outlier detection feature.
+	OutlierDetection json.RawMessage
+
+	// Raw is the resource from the xds response.
+	Raw []byte
+	// TelemetryLabels are the string valued metadata of filter_metadata type
+	// "com.google.csm.telemetry_labels" with keys "service_name" or
+	// "service_namespace".
+	TelemetryLabels map[string]string
+}
+
+// SecurityConfig contains the security configuration received as part of the
+// Cluster resource on the client-side, and as part of the Listener resource on
+// the server-side.
+type SecurityConfig struct {
+	// RootInstanceName identifies the certProvider plugin to be used to fetch
+	// root certificates. This instance name will be resolved to the plugin name
+	// and its associated configuration from the certificate_providers field of
+	// the bootstrap file.
+	RootInstanceName string
+	// RootCertName is the certificate name to be passed to the plugin (looked
+	// up from the bootstrap file) while fetching root certificates.
+	RootCertName string
+	// IdentityInstanceName identifies the certProvider plugin to be used to
+	// fetch identity certificates. This instance name will be resolved to the
+	// plugin name and its associated configuration from the
+	// certificate_providers field of the bootstrap file.
+	IdentityInstanceName string
+	// IdentityCertName is the certificate name to be passed to the plugin
+	// (looked up from the bootstrap file) while fetching identity certificates.
+	IdentityCertName string
+	// SubjectAltNameMatchers is an optional list of match criteria for SANs
+	// specified on the peer certificate. Used only on the client-side.
+	//
+	// Some intricacies:
+	// - If this field is empty, then any peer certificate is accepted.
+	// - If the peer certificate contains a wildcard DNS SAN, and an `exact`
+	//   matcher is configured, a wildcard DNS match is performed instead of a
+	//   regular string comparison.
+	SubjectAltNameMatchers []matcher.StringMatcher
+	// RequireClientCert indicates if the server handshake process expects the
+	// client to present a certificate. Set to true when performing mTLS. Used
+	// only on the server-side.
+	RequireClientCert bool
+	// UseSystemRootCerts indicates that the client should use system root
+	// certificates to validate the server certificate. This field is mutually
+	// exclusive with RootCertName and RootInstanceName. Validation performed
+	// after unmarshalling xDS resources ensures that this field is set only
+	// when both RootCertName and RootInstanceName are empty.
+	UseSystemRootCerts bool
+}
+
+// Equal returns true if sc is equal to other.
+func (sc *SecurityConfig) Equal(other *SecurityConfig) bool {
+	switch {
+	case sc == nil && other == nil:
+		return true
+	case (sc != nil) != (other != nil):
+		return false
+	}
+	switch {
+	case sc.RootInstanceName != other.RootInstanceName:
+		return false
+	case sc.RootCertName != other.RootCertName:
+		return false
+	case sc.IdentityInstanceName != other.IdentityInstanceName:
+		return false
+	case sc.IdentityCertName != other.IdentityCertName:
+		return false
+	case sc.RequireClientCert != other.RequireClientCert:
+		return false
+	case sc.UseSystemRootCerts != other.UseSystemRootCerts:
+		return false
+	default:
+		if len(sc.SubjectAltNameMatchers) != len(other.SubjectAltNameMatchers) {
+			return false
+		}
+		for i := 0; i < len(sc.SubjectAltNameMatchers); i++ {
+			if !sc.SubjectAltNameMatchers[i].Equal(other.SubjectAltNameMatchers[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/type_lds.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/type_lds.go
@@ -1,0 +1,79 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"time"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/httpfilter"
+)
+
+// ListenerUpdate contains information received in an LDS response, which is of
+// interest to the registered LDS watcher.
+type ListenerUpdate struct {
+	// RouteConfigName is the route configuration name corresponding to the
+	// target which is being watched through LDS.
+	//
+	// Exactly one of RouteConfigName and InlineRouteConfig is set.
+	RouteConfigName string
+	// InlineRouteConfig is the inline route configuration (RDS response)
+	// returned inside LDS.
+	//
+	// Exactly one of RouteConfigName and InlineRouteConfig is set.
+	InlineRouteConfig *RouteConfigUpdate
+
+	// MaxStreamDuration contains the HTTP connection manager's
+	// common_http_protocol_options.max_stream_duration field, or zero if
+	// unset.
+	MaxStreamDuration time.Duration
+	// HTTPFilters is a list of HTTP filters (name, config) from the LDS
+	// response.
+	HTTPFilters []HTTPFilter
+	// InboundListenerCfg contains inbound listener configuration.
+	InboundListenerCfg *InboundListenerConfig
+
+	// Raw is the resource from the xds response.
+	Raw []byte
+}
+
+// HTTPFilter represents one HTTP filter from an LDS response's HTTP connection
+// manager field.
+type HTTPFilter struct {
+	// Name is an arbitrary name of the filter.  Used for applying override
+	// settings in virtual host / route / weighted cluster configuration (not
+	// yet supported).
+	Name string
+	// Filter is the HTTP filter found in the registry for the config type.
+	Filter httpfilter.Filter
+	// Config contains the filter's configuration
+	Config httpfilter.FilterConfig
+}
+
+// InboundListenerConfig contains information about the inbound listener, i.e
+// the server-side listener.
+type InboundListenerConfig struct {
+	// Address is the local address on which the inbound listener is expected to
+	// accept incoming connections.
+	Address string
+	// Port is the local port on which the inbound listener is expected to
+	// accept incoming connections.
+	Port string
+	// FilterChains is the list of filter chains associated with this listener.
+	FilterChains *FilterChainManager
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/type_rds.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/type_rds.go
@@ -1,0 +1,182 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"regexp"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/httpfilter"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/matcher"
+	"google.golang.org/grpc/xds/internal/clusterspecifier"
+)
+
+// RouteConfigUpdate contains information received in an RDS response, which is
+// of interest to the registered RDS watcher.
+type RouteConfigUpdate struct {
+	VirtualHosts []*VirtualHost
+	// ClusterSpecifierPlugins are the LB Configurations for any
+	// ClusterSpecifierPlugins referenced by the Route Table.
+	ClusterSpecifierPlugins map[string]clusterspecifier.BalancerConfig
+	// Raw is the resource from the xds response.
+	Raw []byte
+}
+
+// VirtualHost contains the routes for a list of Domains.
+//
+// Note that the domains in this slice can be a wildcard, not an exact string.
+// The consumer of this struct needs to find the best match for its hostname.
+type VirtualHost struct {
+	Domains []string
+	// Routes contains a list of routes, each containing matchers and
+	// corresponding action.
+	Routes []*Route
+	// HTTPFilterConfigOverride contains any HTTP filter config overrides for
+	// the virtual host which may be present.  An individual filter's override
+	// may be unused if the matching Route contains an override for that
+	// filter.
+	HTTPFilterConfigOverride map[string]httpfilter.FilterConfig
+	RetryConfig              *RetryConfig
+}
+
+// RetryConfig contains all retry-related configuration in either a VirtualHost
+// or Route.
+type RetryConfig struct {
+	// RetryOn is a set of status codes on which to retry.  Only Canceled,
+	// DeadlineExceeded, Internal, ResourceExhausted, and Unavailable are
+	// supported; any other values will be omitted.
+	RetryOn      map[codes.Code]bool
+	NumRetries   uint32       // maximum number of retry attempts
+	RetryBackoff RetryBackoff // retry backoff policy
+}
+
+// RetryBackoff describes the backoff policy for retries.
+type RetryBackoff struct {
+	BaseInterval time.Duration // initial backoff duration between attempts
+	MaxInterval  time.Duration // maximum backoff duration
+}
+
+// HashPolicyType specifies the type of HashPolicy from a received RDS Response.
+type HashPolicyType int
+
+const (
+	// HashPolicyTypeHeader specifies to hash a Header in the incoming request.
+	HashPolicyTypeHeader HashPolicyType = iota
+	// HashPolicyTypeChannelID specifies to hash a unique Identifier of the
+	// Channel. This is a 64-bit random int computed at initialization time.
+	HashPolicyTypeChannelID
+)
+
+// HashPolicy specifies the HashPolicy if the upstream cluster uses a hashing
+// load balancer.
+type HashPolicy struct {
+	HashPolicyType HashPolicyType
+	Terminal       bool
+	// Fields used for type HEADER.
+	HeaderName        string
+	Regex             *regexp.Regexp
+	RegexSubstitution string
+}
+
+// RouteActionType is the action of the route from a received RDS response.
+type RouteActionType int
+
+const (
+	// RouteActionUnsupported are routing types currently unsupported by grpc.
+	// According to A36, "A Route with an inappropriate action causes RPCs
+	// matching that route to fail."
+	RouteActionUnsupported RouteActionType = iota
+	// RouteActionRoute is the expected route type on the client side. Route
+	// represents routing a request to some upstream cluster. On the client
+	// side, if an RPC matches to a route that is not RouteActionRoute, the RPC
+	// will fail according to A36.
+	RouteActionRoute
+	// RouteActionNonForwardingAction is the expected route type on the server
+	// side. NonForwardingAction represents when a route will generate a
+	// response directly, without forwarding to an upstream host.
+	RouteActionNonForwardingAction
+)
+
+// Route is both a specification of how to match a request as well as an
+// indication of the action to take upon match.
+type Route struct {
+	Path   *string
+	Prefix *string
+	Regex  *regexp.Regexp
+	// Indicates if prefix/path matching should be case insensitive. The default
+	// is false (case sensitive).
+	CaseInsensitive bool
+	Headers         []*HeaderMatcher
+	Fraction        *uint32
+
+	HashPolicies []*HashPolicy
+
+	// If the matchers above indicate a match, the below configuration is used.
+	// If MaxStreamDuration is nil, it indicates neither of the route action's
+	// max_stream_duration fields (grpc_timeout_header_max nor
+	// max_stream_duration) were set.  In this case, the ListenerUpdate's
+	// MaxStreamDuration field should be used.  If MaxStreamDuration is set to
+	// an explicit zero duration, the application's deadline should be used.
+	MaxStreamDuration *time.Duration
+	// HTTPFilterConfigOverride contains any HTTP filter config overrides for
+	// the route which may be present.  An individual filter's override may be
+	// unused if the matching WeightedCluster contains an override for that
+	// filter.
+	HTTPFilterConfigOverride map[string]httpfilter.FilterConfig
+	RetryConfig              *RetryConfig
+
+	ActionType RouteActionType
+
+	// Only one of the following fields (WeightedClusters or
+	// ClusterSpecifierPlugin) will be set for a route.
+	WeightedClusters map[string]WeightedCluster
+	// ClusterSpecifierPlugin is the name of the Cluster Specifier Plugin that
+	// this Route is linked to, if specified by xDS.
+	ClusterSpecifierPlugin string
+}
+
+// WeightedCluster contains settings for an xds ActionType.WeightedCluster.
+type WeightedCluster struct {
+	// Weight is the relative weight of the cluster.  It will never be zero.
+	Weight uint32
+	// HTTPFilterConfigOverride contains any HTTP filter config overrides for
+	// the weighted cluster which may be present.
+	HTTPFilterConfigOverride map[string]httpfilter.FilterConfig
+}
+
+// HeaderMatcher represents header matchers.
+type HeaderMatcher struct {
+	Name         string
+	InvertMatch  *bool
+	ExactMatch   *string
+	RegexMatch   *regexp.Regexp
+	PrefixMatch  *string
+	SuffixMatch  *string
+	RangeMatch   *Int64Range
+	PresentMatch *bool
+	StringMatch  *matcher.StringMatcher
+}
+
+// Int64Range is a range for header range match.
+type Int64Range struct {
+	Start int64
+	End   int64
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/unmarshal_cds.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/unmarshal_cds.go
@@ -1,0 +1,259 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"errors"
+	"fmt"
+
+	"google.golang.org/grpc/internal/envconfig"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/matcher"
+
+	v3tlspb "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+)
+
+// TransportSocket proto message has a `name` field which is expected to be set
+// to this value by the management server.
+const transportSocketName = "envoy.transport_sockets.tls"
+
+// common is expected to be not nil.
+// The `alpn_protocols` field is ignored.
+func securityConfigFromCommonTLSContext(common *v3tlspb.CommonTlsContext, server bool) (*SecurityConfig, error) {
+	if common.GetTlsParams() != nil {
+		return nil, fmt.Errorf("unsupported tls_params field in CommonTlsContext message: %+v", common)
+	}
+	if common.GetCustomHandshaker() != nil {
+		return nil, fmt.Errorf("unsupported custom_handshaker field in CommonTlsContext message: %+v", common)
+	}
+
+	// For now, if we can't get a valid security config from the new fields, we
+	// fallback to the old deprecated fields.
+	// TODO: Drop support for deprecated fields. NACK if err != nil here.
+	sc, err1 := securityConfigFromCommonTLSContextUsingNewFields(common, server)
+	if sc == nil || sc.Equal(&SecurityConfig{}) {
+		var err error
+		sc, err = securityConfigFromCommonTLSContextWithDeprecatedFields(common, server)
+		if err != nil {
+			// Retain the validation error from using the new fields.
+			return nil, errors.Join(err1, fmt.Errorf("failed to parse config using deprecated fields: %v", err))
+		}
+	}
+	if sc != nil {
+		// sc == nil is a valid case where the control plane has not sent us any
+		// security configuration. xDS creds will use fallback creds.
+		if server {
+			if sc.IdentityInstanceName == "" {
+				return nil, errors.New("security configuration on the server-side does not contain identity certificate provider instance name")
+			}
+		} else {
+			if !sc.UseSystemRootCerts && sc.RootInstanceName == "" {
+				return nil, errors.New("security configuration on the client-side does not contain root certificate provider instance name")
+			}
+		}
+	}
+	return sc, nil
+}
+
+func securityConfigFromCommonTLSContextWithDeprecatedFields(common *v3tlspb.CommonTlsContext, server bool) (*SecurityConfig, error) {
+	// The `CommonTlsContext` contains a
+	// `tls_certificate_certificate_provider_instance` field of type
+	// `CertificateProviderInstance`, which contains the provider instance name
+	// and the certificate name to fetch identity certs.
+	sc := &SecurityConfig{}
+	if identity := common.GetTlsCertificateCertificateProviderInstance(); identity != nil {
+		sc.IdentityInstanceName = identity.GetInstanceName()
+		sc.IdentityCertName = identity.GetCertificateName()
+	}
+
+	// The `CommonTlsContext` contains a `validation_context_type` field which
+	// is a oneof. We can get the values that we are interested in from two of
+	// those possible values:
+	//  - combined validation context:
+	//    - contains a default validation context which holds the list of
+	//      matchers for accepted SANs.
+	//    - contains certificate provider instance configuration
+	//  - certificate provider instance configuration
+	//    - in this case, we do not get a list of accepted SANs.
+	switch t := common.GetValidationContextType().(type) {
+	case *v3tlspb.CommonTlsContext_CombinedValidationContext:
+		combined := common.GetCombinedValidationContext()
+		var matchers []matcher.StringMatcher
+		if def := combined.GetDefaultValidationContext(); def != nil {
+			for _, m := range def.GetMatchSubjectAltNames() {
+				matcher, err := matcher.StringMatcherFromProto(m)
+				if err != nil {
+					return nil, err
+				}
+				matchers = append(matchers, matcher)
+			}
+		}
+		if server && len(matchers) != 0 {
+			return nil, fmt.Errorf("match_subject_alt_names field in validation context is not supported on the server: %v", common)
+		}
+		sc.SubjectAltNameMatchers = matchers
+		if pi := combined.GetValidationContextCertificateProviderInstance(); pi != nil {
+			sc.RootInstanceName = pi.GetInstanceName()
+			sc.RootCertName = pi.GetCertificateName()
+		}
+	case *v3tlspb.CommonTlsContext_ValidationContextCertificateProviderInstance:
+		pi := common.GetValidationContextCertificateProviderInstance()
+		sc.RootInstanceName = pi.GetInstanceName()
+		sc.RootCertName = pi.GetCertificateName()
+	case nil:
+		// It is valid for the validation context to be nil on the server side.
+	default:
+		return nil, fmt.Errorf("validation context contains unexpected type: %T", t)
+	}
+	return sc, nil
+}
+
+// gRFC A29 https://github.com/grpc/proposal/blob/master/A29-xds-tls-security.md
+// specifies the new way to fetch security configuration and says the following:
+//
+// Although there are various ways to obtain certificates as per this proto
+// (which are supported by Envoy), gRPC supports only one of them and that is
+// the `CertificateProviderPluginInstance` proto.
+//
+// This helper function attempts to fetch security configuration from the
+// `CertificateProviderPluginInstance` message, given a CommonTlsContext.
+func securityConfigFromCommonTLSContextUsingNewFields(common *v3tlspb.CommonTlsContext, server bool) (*SecurityConfig, error) {
+	// The `tls_certificate_provider_instance` field of type
+	// `CertificateProviderPluginInstance` is used to fetch the identity
+	// certificate provider.
+	sc := &SecurityConfig{}
+	identity := common.GetTlsCertificateProviderInstance()
+	if identity == nil && len(common.GetTlsCertificates()) != 0 {
+		return nil, fmt.Errorf("expected field tls_certificate_provider_instance is not set, while unsupported field tls_certificates is set in CommonTlsContext message: %+v", common)
+	}
+	if identity == nil && common.GetTlsCertificateSdsSecretConfigs() != nil {
+		return nil, fmt.Errorf("expected field tls_certificate_provider_instance is not set, while unsupported field tls_certificate_sds_secret_configs is set in CommonTlsContext message: %+v", common)
+	}
+	sc.IdentityInstanceName = identity.GetInstanceName()
+	sc.IdentityCertName = identity.GetCertificateName()
+
+	// The `CommonTlsContext` contains a oneof field `validation_context_type`,
+	// which contains the `CertificateValidationContext` message in one of the
+	// following ways:
+	//  - `validation_context` field
+	//    - this is directly of type `CertificateValidationContext`
+	//  - `combined_validation_context` field
+	//    - this is of type `CombinedCertificateValidationContext` and contains
+	//      a `default validation context` field of type
+	//      `CertificateValidationContext`
+	//
+	// The `CertificateValidationContext` message has the following fields that
+	// we are interested in:
+	//  - `ca_certificate_provider_instance`
+	//    - this is of type `CertificateProviderPluginInstance`
+	//  - `system_root_certs`:
+	//    - This indicates the usage of system root certs for validation.
+	//  - `match_subject_alt_names`
+	//    - this is a list of string matchers
+	//
+	// The `CertificateProviderPluginInstance` message contains two fields
+	//  - instance_name
+	//    - this is the certificate provider instance name to be looked up in
+	//      the bootstrap configuration
+	//  - certificate_name
+	//    -  this is an opaque name passed to the certificate provider
+	var validationCtx *v3tlspb.CertificateValidationContext
+	switch typ := common.GetValidationContextType().(type) {
+	case *v3tlspb.CommonTlsContext_ValidationContext:
+		validationCtx = common.GetValidationContext()
+	case *v3tlspb.CommonTlsContext_CombinedValidationContext:
+		validationCtx = common.GetCombinedValidationContext().GetDefaultValidationContext()
+	case nil:
+		// It is valid for the validation context to be nil on the server side.
+		return sc, nil
+	default:
+		return nil, fmt.Errorf("validation context contains unexpected type: %T", typ)
+	}
+	// If we get here, it means that the `CertificateValidationContext` message
+	// was found through one of the supported ways. It is an error if the
+	// validation context is specified, but it does not specify a way to
+	// validate TLS certificates. Peer TLS certs can be verified in the
+	// following ways:
+	// 1. If the ca_certificate_provider_instance field is set, it contains
+	//    information about the certificate provider to be used for the root
+	//    certificates, else
+	// 2. If the system_root_certs field is set, and the config is for a client,
+	//    use the system default root certs.
+	useSystemRootCerts := false
+	if validationCtx.GetCaCertificateProviderInstance() == nil {
+		if server {
+			if validationCtx.GetSystemRootCerts() != nil {
+				// The `system_root_certs` field will not be supported on the
+				// gRPC server side. If `ca_certificate_provider_instance` is
+				// unset and `system_root_certs` is set, the LDS resource will
+				// be NACKed.
+				// - A82
+				return nil, fmt.Errorf("expected field ca_certificate_provider_instance is missing and unexpected field system_root_certs is set for server in CommonTlsContext message: %+v", common)
+			}
+		} else {
+			if validationCtx.GetSystemRootCerts() != nil {
+				useSystemRootCerts = true
+			}
+		}
+	}
+
+	// The following fields are ignored:
+	// - trusted_ca
+	// - watched_directory
+	// - allow_expired_certificate
+	// - trust_chain_verification
+	switch {
+	case len(validationCtx.GetVerifyCertificateSpki()) != 0:
+		return nil, fmt.Errorf("unsupported verify_certificate_spki field in CommonTlsContext message: %+v", common)
+	case len(validationCtx.GetVerifyCertificateHash()) != 0:
+		return nil, fmt.Errorf("unsupported verify_certificate_hash field in CommonTlsContext message: %+v", common)
+	case validationCtx.GetRequireSignedCertificateTimestamp().GetValue():
+		return nil, fmt.Errorf("unsupported require_signed_certificate_timestamp field in CommonTlsContext message: %+v", common)
+	case validationCtx.GetCrl() != nil:
+		return nil, fmt.Errorf("unsupported crl field in CommonTlsContext message: %+v", common)
+	case validationCtx.GetCustomValidatorConfig() != nil:
+		return nil, fmt.Errorf("unsupported custom_validator_config field in CommonTlsContext message: %+v", common)
+	}
+
+	if rootProvider := validationCtx.GetCaCertificateProviderInstance(); rootProvider != nil {
+		sc.RootInstanceName = rootProvider.GetInstanceName()
+		sc.RootCertName = rootProvider.GetCertificateName()
+	} else if useSystemRootCerts {
+		sc.UseSystemRootCerts = true
+	} else if !server && envconfig.XDSSystemRootCertsEnabled {
+		return nil, fmt.Errorf("expected fields ca_certificate_provider_instance and system_root_certs are missing in CommonTlsContext message: %+v", common)
+	} else {
+		// Don't mention the system_root_certs field if it was not checked.
+		return nil, fmt.Errorf("expected field ca_certificate_provider_instance is missing in CommonTlsContext message: %+v", common)
+	}
+
+	var matchers []matcher.StringMatcher
+	for _, m := range validationCtx.GetMatchSubjectAltNames() {
+		matcher, err := matcher.StringMatcherFromProto(m)
+		if err != nil {
+			return nil, err
+		}
+		matchers = append(matchers, matcher)
+	}
+	if server && len(matchers) != 0 {
+		return nil, fmt.Errorf("match_subject_alt_names field in validation context is not supported on the server: %v", common)
+	}
+	sc.SubjectAltNameMatchers = matchers
+	return sc, nil
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/unmarshal_lds.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/unmarshal_lds.go
@@ -1,0 +1,272 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/httpfilter"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v1xdsudpatypepb "github.com/cncf/xds/go/udpa/type/v1"
+	v3xdsxdstypepb "github.com/cncf/xds/go/xds/type/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+)
+
+func unmarshalListenerResource(r []byte) (string, ListenerUpdate, error) {
+	lis := &v3listenerpb.Listener{}
+	if err := proto.Unmarshal(r, lis); err != nil {
+		return "", ListenerUpdate{}, fmt.Errorf("failed to unmarshal resource: %v", err)
+	}
+
+	lu, err := processListener(lis)
+	if err != nil {
+		return lis.GetName(), ListenerUpdate{}, err
+	}
+	lu.Raw = r
+	return lis.GetName(), *lu, nil
+}
+
+func processListener(lis *v3listenerpb.Listener) (*ListenerUpdate, error) {
+	if lis.GetApiListener() != nil {
+		return processClientSideListener(lis)
+	}
+	return processServerSideListener(lis)
+}
+
+// processClientSideListener checks if the provided Listener proto meets
+// the expected criteria. If so, it returns a non-empty routeConfigName.
+func processClientSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, error) {
+	update := &ListenerUpdate{}
+
+	apiLisAny := lis.GetApiListener().GetApiListener()
+	if !IsHTTPConnManagerResource(apiLisAny.GetTypeUrl()) {
+		return nil, fmt.Errorf("unexpected http connection manager resource type: %q", apiLisAny.GetTypeUrl())
+	}
+	apiLis := &v3httppb.HttpConnectionManager{}
+	if err := proto.Unmarshal(apiLisAny.GetValue(), apiLis); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal api_listener: %v", err)
+	}
+	// "HttpConnectionManager.xff_num_trusted_hops must be unset or zero and
+	// HttpConnectionManager.original_ip_detection_extensions must be empty. If
+	// either field has an incorrect value, the Listener must be NACKed." - A41
+	if apiLis.XffNumTrustedHops != 0 {
+		return nil, fmt.Errorf("xff_num_trusted_hops must be unset or zero %+v", apiLis)
+	}
+	if len(apiLis.OriginalIpDetectionExtensions) != 0 {
+		return nil, fmt.Errorf("original_ip_detection_extensions must be empty %+v", apiLis)
+	}
+
+	switch apiLis.RouteSpecifier.(type) {
+	case *v3httppb.HttpConnectionManager_Rds:
+		if configsource := apiLis.GetRds().GetConfigSource(); configsource.GetAds() == nil && configsource.GetSelf() == nil {
+			return nil, fmt.Errorf("LDS's RDS configSource is not ADS or Self: %+v", lis)
+		}
+		name := apiLis.GetRds().GetRouteConfigName()
+		if name == "" {
+			return nil, fmt.Errorf("empty route_config_name: %+v", lis)
+		}
+		update.RouteConfigName = name
+	case *v3httppb.HttpConnectionManager_RouteConfig:
+		routeU, err := generateRDSUpdateFromRouteConfiguration(apiLis.GetRouteConfig())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse inline RDS resp: %v", err)
+		}
+		update.InlineRouteConfig = &routeU
+	case nil:
+		return nil, fmt.Errorf("no RouteSpecifier: %+v", apiLis)
+	default:
+		return nil, fmt.Errorf("unsupported type %T for RouteSpecifier", apiLis.RouteSpecifier)
+	}
+
+	// The following checks and fields only apply to xDS protocol versions v3+.
+
+	update.MaxStreamDuration = apiLis.GetCommonHttpProtocolOptions().GetMaxStreamDuration().AsDuration()
+
+	var err error
+	if update.HTTPFilters, err = processHTTPFilters(apiLis.GetHttpFilters(), false); err != nil {
+		return nil, err
+	}
+
+	return update, nil
+}
+
+func unwrapHTTPFilterConfig(config *anypb.Any) (proto.Message, string, error) {
+	switch {
+	case config.MessageIs(&v3xdsxdstypepb.TypedStruct{}):
+		// The real type name is inside the new TypedStruct message.
+		s := new(v3xdsxdstypepb.TypedStruct)
+		if err := config.UnmarshalTo(s); err != nil {
+			return nil, "", fmt.Errorf("error unmarshalling TypedStruct filter config: %v", err)
+		}
+		return s, s.GetTypeUrl(), nil
+	case config.MessageIs(&v1xdsudpatypepb.TypedStruct{}):
+		// The real type name is inside the old TypedStruct message.
+		s := new(v1xdsudpatypepb.TypedStruct)
+		if err := config.UnmarshalTo(s); err != nil {
+			return nil, "", fmt.Errorf("error unmarshalling TypedStruct filter config: %v", err)
+		}
+		return s, s.GetTypeUrl(), nil
+	default:
+		return config, config.GetTypeUrl(), nil
+	}
+}
+
+func validateHTTPFilterConfig(cfg *anypb.Any, lds, optional bool) (httpfilter.Filter, httpfilter.FilterConfig, error) {
+	config, typeURL, err := unwrapHTTPFilterConfig(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	filterBuilder := httpfilter.Get(typeURL)
+	if filterBuilder == nil {
+		if optional {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("no filter implementation found for %q", typeURL)
+	}
+	parseFunc := filterBuilder.ParseFilterConfig
+	if !lds {
+		parseFunc = filterBuilder.ParseFilterConfigOverride
+	}
+	filterConfig, err := parseFunc(config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error parsing config for filter %q: %v", typeURL, err)
+	}
+	return filterBuilder, filterConfig, nil
+}
+
+func processHTTPFilterOverrides(cfgs map[string]*anypb.Any) (map[string]httpfilter.FilterConfig, error) {
+	if len(cfgs) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]httpfilter.FilterConfig)
+	for name, cfg := range cfgs {
+		optional := false
+		s := new(v3routepb.FilterConfig)
+		if cfg.MessageIs(s) {
+			if err := cfg.UnmarshalTo(s); err != nil {
+				return nil, fmt.Errorf("filter override %q: error unmarshalling FilterConfig: %v", name, err)
+			}
+			cfg = s.GetConfig()
+			optional = s.GetIsOptional()
+		}
+
+		httpFilter, config, err := validateHTTPFilterConfig(cfg, false, optional)
+		if err != nil {
+			return nil, fmt.Errorf("filter override %q: %v", name, err)
+		}
+		if httpFilter == nil {
+			// Optional configs are ignored.
+			continue
+		}
+		m[name] = config
+	}
+	return m, nil
+}
+
+func processHTTPFilters(filters []*v3httppb.HttpFilter, server bool) ([]HTTPFilter, error) {
+	ret := make([]HTTPFilter, 0, len(filters))
+	seenNames := make(map[string]bool, len(filters))
+	for _, filter := range filters {
+		name := filter.GetName()
+		if name == "" {
+			return nil, errors.New("filter missing name field")
+		}
+		if seenNames[name] {
+			return nil, fmt.Errorf("duplicate filter name %q", name)
+		}
+		seenNames[name] = true
+
+		httpFilter, config, err := validateHTTPFilterConfig(filter.GetTypedConfig(), true, filter.GetIsOptional())
+		if err != nil {
+			return nil, err
+		}
+		if httpFilter == nil {
+			// Optional configs are ignored.
+			continue
+		}
+		if server {
+			if _, ok := httpFilter.(httpfilter.ServerInterceptorBuilder); !ok {
+				if filter.GetIsOptional() {
+					continue
+				}
+				return nil, fmt.Errorf("HTTP filter %q not supported server-side", name)
+			}
+		} else if _, ok := httpFilter.(httpfilter.ClientInterceptorBuilder); !ok {
+			if filter.GetIsOptional() {
+				continue
+			}
+			return nil, fmt.Errorf("HTTP filter %q not supported client-side", name)
+		}
+
+		// Save name/config
+		ret = append(ret, HTTPFilter{Name: name, Filter: httpFilter, Config: config})
+	}
+	// "Validation will fail if a terminal filter is not the last filter in the
+	// chain or if a non-terminal filter is the last filter in the chain." - A39
+	if len(ret) == 0 {
+		return nil, fmt.Errorf("http filters list is empty")
+	}
+	var i int
+	for ; i < len(ret)-1; i++ {
+		if ret[i].Filter.IsTerminal() {
+			return nil, fmt.Errorf("http filter %q is a terminal filter but it is not last in the filter chain", ret[i].Name)
+		}
+	}
+	if !ret[i].Filter.IsTerminal() {
+		return nil, fmt.Errorf("http filter %q is not a terminal filter", ret[len(ret)-1].Name)
+	}
+	return ret, nil
+}
+
+func processServerSideListener(lis *v3listenerpb.Listener) (*ListenerUpdate, error) {
+	if n := len(lis.ListenerFilters); n != 0 {
+		return nil, fmt.Errorf("unsupported field 'listener_filters' contains %d entries", n)
+	}
+	if useOrigDst := lis.GetUseOriginalDst(); useOrigDst != nil && useOrigDst.GetValue() {
+		return nil, errors.New("unsupported field 'use_original_dst' is present and set to true")
+	}
+	addr := lis.GetAddress()
+	if addr == nil {
+		return nil, fmt.Errorf("no address field in LDS response: %+v", lis)
+	}
+	sockAddr := addr.GetSocketAddress()
+	if sockAddr == nil {
+		return nil, fmt.Errorf("no socket_address field in LDS response: %+v", lis)
+	}
+	lu := &ListenerUpdate{
+		InboundListenerCfg: &InboundListenerConfig{
+			Address: sockAddr.GetAddress(),
+			Port:    strconv.Itoa(int(sockAddr.GetPortValue())),
+		},
+	}
+
+	fcMgr, err := NewFilterChainManager(lis)
+	if err != nil {
+		return nil, err
+	}
+	lu.InboundListenerCfg.FilterChains = fcMgr
+	return lu, nil
+}

--- a/xds/internal/clients/xdsclient/internal/testutils/unmarshal_rds.go
+++ b/xds/internal/clients/xdsclient/internal/testutils/unmarshal_rds.go
@@ -1,0 +1,414 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/codes"
+
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/matcher"
+	"google.golang.org/grpc/xds/internal/clusterspecifier"
+
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3typepb "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+)
+
+// generateRDSUpdateFromRouteConfiguration checks if the provided
+// RouteConfiguration meets the expected criteria. If so, it returns a
+// RouteConfigUpdate with nil error.
+//
+// A RouteConfiguration resource is considered valid when only if it contains a
+// VirtualHost whose domain field matches the server name from the URI passed
+// to the client channel, and it contains a clusterName or a weighted cluster.
+//
+// The RouteConfiguration includes a list of virtualHosts, which may have zero
+// or more elements. We are interested in the element whose domains field
+// matches the server name specified in the "xds:" URI. The only field in the
+// VirtualHost proto that the we are interested in is the list of routes. We
+// only look at the last route in the list (the default route), whose match
+// field must be empty and whose route field must be set.  Inside that route
+// message, the cluster field will contain the clusterName or weighted clusters
+// we are looking for.
+func generateRDSUpdateFromRouteConfiguration(rc *v3routepb.RouteConfiguration) (RouteConfigUpdate, error) {
+	vhs := make([]*VirtualHost, 0, len(rc.GetVirtualHosts()))
+	csps, err := processClusterSpecifierPlugins(rc.ClusterSpecifierPlugins)
+	if err != nil {
+		return RouteConfigUpdate{}, fmt.Errorf("received route is invalid: %v", err)
+	}
+	// cspNames represents all the cluster specifiers referenced by Route
+	// Actions - any cluster specifiers not referenced by a Route Action can be
+	// ignored and not emitted by the xdsclient.
+	var cspNames = make(map[string]bool)
+	for _, vh := range rc.GetVirtualHosts() {
+		routes, cspNs, err := routesProtoToSlice(vh.Routes, csps)
+		if err != nil {
+			return RouteConfigUpdate{}, fmt.Errorf("received route is invalid: %v", err)
+		}
+		for n := range cspNs {
+			cspNames[n] = true
+		}
+		rc, err := generateRetryConfig(vh.GetRetryPolicy())
+		if err != nil {
+			return RouteConfigUpdate{}, fmt.Errorf("received route is invalid: %v", err)
+		}
+		vhOut := &VirtualHost{
+			Domains:     vh.GetDomains(),
+			Routes:      routes,
+			RetryConfig: rc,
+		}
+		cfgs, err := processHTTPFilterOverrides(vh.GetTypedPerFilterConfig())
+		if err != nil {
+			return RouteConfigUpdate{}, fmt.Errorf("virtual host %+v: %v", vh, err)
+		}
+		vhOut.HTTPFilterConfigOverride = cfgs
+		vhs = append(vhs, vhOut)
+	}
+
+	// "For any entry in the RouteConfiguration.cluster_specifier_plugins not
+	// referenced by an enclosed ActionType's cluster_specifier_plugin, the xDS
+	// client should not provide it to its consumers." - RLS in xDS Design
+	for name := range csps {
+		if !cspNames[name] {
+			delete(csps, name)
+		}
+	}
+
+	return RouteConfigUpdate{VirtualHosts: vhs, ClusterSpecifierPlugins: csps}, nil
+}
+
+func processClusterSpecifierPlugins(csps []*v3routepb.ClusterSpecifierPlugin) (map[string]clusterspecifier.BalancerConfig, error) {
+	cspCfgs := make(map[string]clusterspecifier.BalancerConfig)
+	// "The xDS client will inspect all elements of the
+	// cluster_specifier_plugins field looking up a plugin based on the
+	// extension.typed_config of each." - RLS in xDS design
+	for _, csp := range csps {
+		cs := clusterspecifier.Get(csp.GetExtension().GetTypedConfig().GetTypeUrl())
+		if cs == nil {
+			if csp.GetIsOptional() {
+				// "If a plugin is not supported but has is_optional set, then
+				// we will ignore any routes that point to that plugin"
+				cspCfgs[csp.GetExtension().GetName()] = nil
+				continue
+			}
+			// "If no plugin is registered for it, the resource will be NACKed."
+			// - RLS in xDS design
+			return nil, fmt.Errorf("cluster specifier %q of type %q was not found", csp.GetExtension().GetName(), csp.GetExtension().GetTypedConfig().GetTypeUrl())
+		}
+		lbCfg, err := cs.ParseClusterSpecifierConfig(csp.GetExtension().GetTypedConfig())
+		if err != nil {
+			// "If a plugin is found, the value of the typed_config field will
+			// be passed to it's conversion method, and if an error is
+			// encountered, the resource will be NACKED." - RLS in xDS design
+			return nil, fmt.Errorf("error: %q parsing config %q for cluster specifier %q of type %q", err, csp.GetExtension().GetTypedConfig(), csp.GetExtension().GetName(), csp.GetExtension().GetTypedConfig().GetTypeUrl())
+		}
+		// "If all cluster specifiers are valid, the xDS client will store the
+		// configurations in a map keyed by the name of the extension instance." -
+		// RLS in xDS Design
+		cspCfgs[csp.GetExtension().GetName()] = lbCfg
+	}
+	return cspCfgs, nil
+}
+
+func generateRetryConfig(rp *v3routepb.RetryPolicy) (*RetryConfig, error) {
+	if rp == nil {
+		return nil, nil
+	}
+
+	cfg := &RetryConfig{RetryOn: make(map[codes.Code]bool)}
+	for _, s := range strings.Split(rp.GetRetryOn(), ",") {
+		switch strings.TrimSpace(strings.ToLower(s)) {
+		case "cancelled":
+			cfg.RetryOn[codes.Canceled] = true
+		case "deadline-exceeded":
+			cfg.RetryOn[codes.DeadlineExceeded] = true
+		case "internal":
+			cfg.RetryOn[codes.Internal] = true
+		case "resource-exhausted":
+			cfg.RetryOn[codes.ResourceExhausted] = true
+		case "unavailable":
+			cfg.RetryOn[codes.Unavailable] = true
+		}
+	}
+
+	if rp.NumRetries == nil {
+		cfg.NumRetries = 1
+	} else {
+		cfg.NumRetries = rp.GetNumRetries().Value
+		if cfg.NumRetries < 1 {
+			return nil, fmt.Errorf("retry_policy.num_retries = %v; must be >= 1", cfg.NumRetries)
+		}
+	}
+
+	backoff := rp.GetRetryBackOff()
+	if backoff == nil {
+		cfg.RetryBackoff.BaseInterval = 25 * time.Millisecond
+	} else {
+		cfg.RetryBackoff.BaseInterval = backoff.GetBaseInterval().AsDuration()
+		if cfg.RetryBackoff.BaseInterval <= 0 {
+			return nil, fmt.Errorf("retry_policy.base_interval = %v; must be > 0", cfg.RetryBackoff.BaseInterval)
+		}
+	}
+	if max := backoff.GetMaxInterval(); max == nil {
+		cfg.RetryBackoff.MaxInterval = 10 * cfg.RetryBackoff.BaseInterval
+	} else {
+		cfg.RetryBackoff.MaxInterval = max.AsDuration()
+		if cfg.RetryBackoff.MaxInterval <= 0 {
+			return nil, fmt.Errorf("retry_policy.max_interval = %v; must be > 0", cfg.RetryBackoff.MaxInterval)
+		}
+	}
+
+	if len(cfg.RetryOn) == 0 {
+		return &RetryConfig{}, nil
+	}
+	return cfg, nil
+}
+
+func routesProtoToSlice(routes []*v3routepb.Route, csps map[string]clusterspecifier.BalancerConfig) ([]*Route, map[string]bool, error) {
+	var routesRet []*Route
+	var cspNames = make(map[string]bool)
+	for _, r := range routes {
+		match := r.GetMatch()
+		if match == nil {
+			return nil, nil, fmt.Errorf("route %+v doesn't have a match", r)
+		}
+
+		if len(match.GetQueryParameters()) != 0 {
+			// Ignore route with query parameters.
+			logger.Warningf("Ignoring route %+v with query parameter matchers", r)
+			continue
+		}
+
+		pathSp := match.GetPathSpecifier()
+		if pathSp == nil {
+			return nil, nil, fmt.Errorf("route %+v doesn't have a path specifier", r)
+		}
+
+		var route Route
+		switch pt := pathSp.(type) {
+		case *v3routepb.RouteMatch_Prefix:
+			route.Prefix = &pt.Prefix
+		case *v3routepb.RouteMatch_Path:
+			route.Path = &pt.Path
+		case *v3routepb.RouteMatch_SafeRegex:
+			regex := pt.SafeRegex.GetRegex()
+			re, err := regexp.Compile(regex)
+			if err != nil {
+				return nil, nil, fmt.Errorf("route %+v contains an invalid regex %q", r, regex)
+			}
+			route.Regex = re
+		default:
+			return nil, nil, fmt.Errorf("route %+v has an unrecognized path specifier: %+v", r, pt)
+		}
+
+		if caseSensitive := match.GetCaseSensitive(); caseSensitive != nil {
+			route.CaseInsensitive = !caseSensitive.Value
+		}
+
+		for _, h := range match.GetHeaders() {
+			var header HeaderMatcher
+			switch ht := h.GetHeaderMatchSpecifier().(type) {
+			case *v3routepb.HeaderMatcher_ExactMatch:
+				header.ExactMatch = &ht.ExactMatch
+			case *v3routepb.HeaderMatcher_SafeRegexMatch:
+				regex := ht.SafeRegexMatch.GetRegex()
+				re, err := regexp.Compile(regex)
+				if err != nil {
+					return nil, nil, fmt.Errorf("route %+v contains an invalid regex %q", r, regex)
+				}
+				header.RegexMatch = re
+			case *v3routepb.HeaderMatcher_RangeMatch:
+				header.RangeMatch = &Int64Range{
+					Start: ht.RangeMatch.Start,
+					End:   ht.RangeMatch.End,
+				}
+			case *v3routepb.HeaderMatcher_PresentMatch:
+				header.PresentMatch = &ht.PresentMatch
+			case *v3routepb.HeaderMatcher_PrefixMatch:
+				header.PrefixMatch = &ht.PrefixMatch
+			case *v3routepb.HeaderMatcher_SuffixMatch:
+				header.SuffixMatch = &ht.SuffixMatch
+			case *v3routepb.HeaderMatcher_StringMatch:
+				sm, err := matcher.StringMatcherFromProto(ht.StringMatch)
+				if err != nil {
+					return nil, nil, fmt.Errorf("route %+v has an invalid string matcher: %v", err, ht.StringMatch)
+				}
+				header.StringMatch = &sm
+			default:
+				return nil, nil, fmt.Errorf("route %+v has an unrecognized header matcher: %+v", r, ht)
+			}
+			header.Name = h.GetName()
+			invert := h.GetInvertMatch()
+			header.InvertMatch = &invert
+			route.Headers = append(route.Headers, &header)
+		}
+
+		if fr := match.GetRuntimeFraction(); fr != nil {
+			d := fr.GetDefaultValue()
+			n := d.GetNumerator()
+			switch d.GetDenominator() {
+			case v3typepb.FractionalPercent_HUNDRED:
+				n *= 10000
+			case v3typepb.FractionalPercent_TEN_THOUSAND:
+				n *= 100
+			case v3typepb.FractionalPercent_MILLION:
+			}
+			route.Fraction = &n
+		}
+
+		switch r.GetAction().(type) {
+		case *v3routepb.Route_Route:
+			route.WeightedClusters = make(map[string]WeightedCluster)
+			action := r.GetRoute()
+
+			// Hash Policies are only applicable for a Ring Hash LB.
+			hp, err := hashPoliciesProtoToSlice(action.HashPolicy)
+			if err != nil {
+				return nil, nil, err
+			}
+			route.HashPolicies = hp
+
+			switch a := action.GetClusterSpecifier().(type) {
+			case *v3routepb.RouteAction_Cluster:
+				route.WeightedClusters[a.Cluster] = WeightedCluster{Weight: 1}
+			case *v3routepb.RouteAction_WeightedClusters:
+				wcs := a.WeightedClusters
+				var totalWeight uint64
+				for _, c := range wcs.Clusters {
+					w := c.GetWeight().GetValue()
+					if w == 0 {
+						continue
+					}
+					totalWeight += uint64(w)
+					if totalWeight > math.MaxUint32 {
+						return nil, nil, fmt.Errorf("xds: total weight of clusters exceeds MaxUint32")
+					}
+					wc := WeightedCluster{Weight: w}
+					cfgs, err := processHTTPFilterOverrides(c.GetTypedPerFilterConfig())
+					if err != nil {
+						return nil, nil, fmt.Errorf("route %+v, action %+v: %v", r, a, err)
+					}
+					wc.HTTPFilterConfigOverride = cfgs
+					route.WeightedClusters[c.GetName()] = wc
+				}
+				if totalWeight == 0 {
+					return nil, nil, fmt.Errorf("route %+v, action %+v, has no valid cluster in WeightedCluster action", r, a)
+				}
+			case *v3routepb.RouteAction_ClusterSpecifierPlugin:
+				// gRFC A28 was updated to say the following:
+				//
+				// The route’s action field must be route, and its
+				// cluster_specifier:
+				// - Can be Cluster
+				// - Can be Weighted_clusters
+				// - Can be unset or an unsupported field. The route containing
+				//   this action will be ignored.
+				//
+				// This means that if this env var is not set, we should treat
+				// it as if it we didn't know about the cluster_specifier_plugin
+				// at all.
+				if _, ok := csps[a.ClusterSpecifierPlugin]; !ok {
+					// "When processing RouteActions, if any action includes a
+					// cluster_specifier_plugin value that is not in
+					// RouteConfiguration.cluster_specifier_plugins, the
+					// resource will be NACKed." - RLS in xDS design
+					return nil, nil, fmt.Errorf("route %+v, action %+v, specifies a cluster specifier plugin %+v that is not in Route Configuration", r, a, a.ClusterSpecifierPlugin)
+				}
+				if csps[a.ClusterSpecifierPlugin] == nil {
+					logger.Warningf("Ignoring route %+v with optional and unsupported cluster specifier plugin %+v", r, a.ClusterSpecifierPlugin)
+					continue
+				}
+				cspNames[a.ClusterSpecifierPlugin] = true
+				route.ClusterSpecifierPlugin = a.ClusterSpecifierPlugin
+			default:
+				logger.Warningf("Ignoring route %+v with unknown ClusterSpecifier %+v", r, a)
+				continue
+			}
+
+			msd := action.GetMaxStreamDuration()
+			// Prefer grpc_timeout_header_max, if set.
+			dur := msd.GetGrpcTimeoutHeaderMax()
+			if dur == nil {
+				dur = msd.GetMaxStreamDuration()
+			}
+			if dur != nil {
+				d := dur.AsDuration()
+				route.MaxStreamDuration = &d
+			}
+
+			route.RetryConfig, err = generateRetryConfig(action.GetRetryPolicy())
+			if err != nil {
+				return nil, nil, fmt.Errorf("route %+v, action %+v: %v", r, action, err)
+			}
+
+			route.ActionType = RouteActionRoute
+
+		case *v3routepb.Route_NonForwardingAction:
+			// Expected to be used on server side.
+			route.ActionType = RouteActionNonForwardingAction
+		default:
+			route.ActionType = RouteActionUnsupported
+		}
+
+		cfgs, err := processHTTPFilterOverrides(r.GetTypedPerFilterConfig())
+		if err != nil {
+			return nil, nil, fmt.Errorf("route %+v: %v", r, err)
+		}
+		route.HTTPFilterConfigOverride = cfgs
+		routesRet = append(routesRet, &route)
+	}
+	return routesRet, cspNames, nil
+}
+
+func hashPoliciesProtoToSlice(policies []*v3routepb.RouteAction_HashPolicy) ([]*HashPolicy, error) {
+	var hashPoliciesRet []*HashPolicy
+	for _, p := range policies {
+		policy := HashPolicy{Terminal: p.Terminal}
+		switch p.GetPolicySpecifier().(type) {
+		case *v3routepb.RouteAction_HashPolicy_Header_:
+			policy.HashPolicyType = HashPolicyTypeHeader
+			policy.HeaderName = p.GetHeader().GetHeaderName()
+			if rr := p.GetHeader().GetRegexRewrite(); rr != nil {
+				regex := rr.GetPattern().GetRegex()
+				re, err := regexp.Compile(regex)
+				if err != nil {
+					return nil, fmt.Errorf("hash policy %+v contains an invalid regex %q", p, regex)
+				}
+				policy.Regex = re
+				policy.RegexSubstitution = rr.GetSubstitution()
+			}
+		case *v3routepb.RouteAction_HashPolicy_FilterState_:
+			if p.GetFilterState().GetKey() != "io.grpc.channel_id" {
+				logger.Warningf("Ignoring hash policy %+v with invalid key for filter state policy %q", p, p.GetFilterState().GetKey())
+				continue
+			}
+			policy.HashPolicyType = HashPolicyTypeChannelID
+		default:
+			logger.Warningf("Ignoring unsupported hash policy %T", p.GetPolicySpecifier())
+			continue
+		}
+
+		hashPoliciesRet = append(hashPoliciesRet, &policy)
+	}
+	return hashPoliciesRet, nil
+}

--- a/xds/internal/clients/xdsclient/internal/xdsresource/errors.go
+++ b/xds/internal/clients/xdsclient/internal/xdsresource/errors.go
@@ -1,0 +1,79 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsresource
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrorType is the type of the error that the watcher will receive from the xds
+// client.
+type ErrorType int
+
+const (
+	// ErrorTypeUnknown indicates the error doesn't have a specific type. It is
+	// the default value, and is returned if the error is not an xds error.
+	ErrorTypeUnknown ErrorType = iota
+	// ErrorTypeConnection indicates a connection error from the gRPC client.
+	ErrorTypeConnection
+	// ErrorTypeResourceNotFound indicates a resource is not found from the xds
+	// response. It's typically returned if the resource is removed in the xds
+	// server.
+	ErrorTypeResourceNotFound
+	// ErrorTypeResourceTypeUnsupported indicates the receipt of a message from
+	// the management server with resources of an unsupported resource type.
+	ErrorTypeResourceTypeUnsupported
+	// ErrTypeStreamFailedAfterRecv indicates an ADS stream error, after
+	// successful receipt of at least one message from the server.
+	ErrTypeStreamFailedAfterRecv
+	// ErrorTypeNACKed indicates that configuration provided by the xDS management
+	// server was NACKed.
+	ErrorTypeNACKed
+)
+
+type xdsClientError struct {
+	t    ErrorType
+	desc string
+}
+
+func (e *xdsClientError) Error() string {
+	return e.desc
+}
+
+// NewErrorf creates an xDS client error. The callbacks are called with this
+// error, to pass additional information about the error.
+func NewErrorf(t ErrorType, format string, args ...any) error {
+	return &xdsClientError{t: t, desc: fmt.Sprintf(format, args...)}
+}
+
+// NewError creates an xDS client error. The callbacks are called with this
+// error, to pass additional information about the error.
+func NewError(t ErrorType, message string) error {
+	return NewErrorf(t, "%s", message)
+}
+
+// ErrType returns the error's type.
+func ErrType(e error) ErrorType {
+	var xe *xdsClientError
+	if ok := errors.As(e, &xe); ok {
+		return xe.t
+	}
+	return ErrorTypeUnknown
+}

--- a/xds/internal/clients/xdsclient/internal/xdsresource/name.go
+++ b/xds/internal/clients/xdsclient/internal/xdsresource/name.go
@@ -1,0 +1,128 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsresource
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// FederationScheme is the scheme of a federation resource name.
+const FederationScheme = "xdstp"
+
+// Name contains the parsed component of an xDS resource name.
+//
+// An xDS resource name is in the format of
+// xdstp://[{authority}]/{resource type}/{id/*}?{context parameters}{#processing directive,*}
+//
+// See
+// https://github.com/cncf/xds/blob/main/proposals/TP1-xds-transport-next.md#uri-based-xds-resource-names
+// for details, and examples.
+type Name struct {
+	Scheme    string
+	Authority string
+	Type      string
+	ID        string
+
+	ContextParams map[string]string
+
+	processingDirective string
+}
+
+// ParseName splits the name and returns a struct representation of the Name.
+//
+// If the name isn't a valid new-style xDS name, field ID is set to the input.
+// Note that this is not an error, because we still support the old-style
+// resource names (those not starting with "xdstp:").
+//
+// The caller can tell if the parsing is successful by checking the returned
+// Scheme.
+func ParseName(name string) *Name {
+	if !strings.Contains(name, "://") {
+		// Only the long form URL, with ://, is valid.
+		return &Name{ID: name}
+	}
+	parsed, err := url.Parse(name)
+	if err != nil {
+		return &Name{ID: name}
+	}
+
+	ret := &Name{
+		Scheme:    parsed.Scheme,
+		Authority: parsed.Host,
+	}
+	split := strings.SplitN(parsed.Path, "/", 3)
+	if len(split) < 3 {
+		// Path is in the format of "/type/id". There must be at least 3
+		// segments after splitting.
+		return &Name{ID: name}
+	}
+	ret.Type = split[1]
+	ret.ID = split[2]
+	if len(parsed.Query()) != 0 {
+		ret.ContextParams = make(map[string]string)
+		for k, vs := range parsed.Query() {
+			if len(vs) > 0 {
+				// We only keep one value of each key. Behavior for multiple values
+				// is undefined.
+				ret.ContextParams[k] = vs[0]
+			}
+		}
+	}
+	// TODO: processing directive (the part comes after "#" in the URL, stored
+	// in parsed.RawFragment) is kept but not processed. Add support for that
+	// when it's needed.
+	ret.processingDirective = parsed.RawFragment
+	return ret
+}
+
+// String returns a canonicalized string of name. The context parameters are
+// sorted by the keys.
+func (n *Name) String() string {
+	if n.Scheme == "" {
+		return n.ID
+	}
+
+	// Sort and build query.
+	keys := make([]string, 0, len(n.ContextParams))
+	for k := range n.ContextParams {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var pairs []string
+	for _, k := range keys {
+		pairs = append(pairs, strings.Join([]string{k, n.ContextParams[k]}, "="))
+	}
+	rawQuery := strings.Join(pairs, "&")
+
+	path := n.Type
+	if n.ID != "" {
+		path = "/" + path + "/" + n.ID
+	}
+
+	tempURL := &url.URL{
+		Scheme:      n.Scheme,
+		Host:        n.Authority,
+		Path:        path,
+		RawQuery:    rawQuery,
+		RawFragment: n.processingDirective,
+	}
+	return tempURL.String()
+}

--- a/xds/internal/clients/xdsclient/internal/xdsresource/type.go
+++ b/xds/internal/clients/xdsclient/internal/xdsresource/type.go
@@ -1,0 +1,136 @@
+/*
+ *
+ * Copyright 2021 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xdsresource
+
+import (
+	"time"
+
+	"google.golang.org/grpc/xds/internal/xdsclient/xdsresource/version"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+)
+
+// UpdateValidatorFunc performs validations on update structs using
+// context/logic available at the xdsClient layer. Since these validation are
+// performed on internal update structs, they can be shared between different
+// API clients.
+type UpdateValidatorFunc func(any) error
+
+// UpdateMetadata contains the metadata for each update, including timestamp,
+// raw message, and so on.
+type UpdateMetadata struct {
+	// Status is the status of this resource, e.g. ACKed, NACKed, or
+	// Not_exist(removed).
+	Status ServiceStatus
+	// Version is the version of the xds response. Note that this is the version
+	// of the resource in use (previous ACKed). If a response is NACKed, the
+	// NACKed version is in ErrState.
+	Version string
+	// Timestamp is when the response is received.
+	Timestamp time.Time
+	// ErrState is set when the update is NACKed.
+	ErrState *UpdateErrorMetadata
+}
+
+// IsListenerResource returns true if the provider URL corresponds to an xDS
+// Listener resource.
+func IsListenerResource(url string) bool {
+	return url == version.V3ListenerURL
+}
+
+// IsHTTPConnManagerResource returns true if the provider URL corresponds to an xDS
+// HTTPConnManager resource.
+func IsHTTPConnManagerResource(url string) bool {
+	return url == version.V3HTTPConnManagerURL
+}
+
+// IsRouteConfigResource returns true if the provider URL corresponds to an xDS
+// RouteConfig resource.
+func IsRouteConfigResource(url string) bool {
+	return url == version.V3RouteConfigURL
+}
+
+// IsClusterResource returns true if the provider URL corresponds to an xDS
+// Cluster resource.
+func IsClusterResource(url string) bool {
+	return url == version.V3ClusterURL
+}
+
+// IsEndpointsResource returns true if the provider URL corresponds to an xDS
+// Endpoints resource.
+func IsEndpointsResource(url string) bool {
+	return url == version.V3EndpointsURL
+}
+
+// UnwrapResource unwraps and returns the inner resource if it's in a resource
+// wrapper. The original resource is returned if it's not wrapped.
+func UnwrapResource(r *anypb.Any) (*anypb.Any, error) {
+	url := r.GetTypeUrl()
+	if url != version.V3ResourceWrapperURL {
+		// Not wrapped.
+		return r, nil
+	}
+	inner := &v3discoverypb.Resource{}
+	if err := proto.Unmarshal(r.GetValue(), inner); err != nil {
+		return nil, err
+	}
+	return inner.Resource, nil
+}
+
+// ServiceStatus is the status of the update.
+type ServiceStatus int
+
+const (
+	// ServiceStatusUnknown is the default state, before a watch is started for
+	// the resource.
+	ServiceStatusUnknown ServiceStatus = iota
+	// ServiceStatusRequested is when the watch is started, but before and
+	// response is received.
+	ServiceStatusRequested
+	// ServiceStatusNotExist is when the resource doesn't exist in
+	// state-of-the-world responses (e.g. LDS and CDS), which means the resource
+	// is removed by the management server.
+	ServiceStatusNotExist // Resource is removed in the server, in LDS/CDS.
+	// ServiceStatusACKed is when the resource is ACKed.
+	ServiceStatusACKed
+	// ServiceStatusNACKed is when the resource is NACKed.
+	ServiceStatusNACKed
+)
+
+// UpdateErrorMetadata is part of UpdateMetadata. It contains the error state
+// when a response is NACKed.
+type UpdateErrorMetadata struct {
+	// Version is the version of the NACKed response.
+	Version string
+	// Err contains why the response was NACKed.
+	Err error
+	// Timestamp is when the NACKed response was received.
+	Timestamp time.Time
+}
+
+// UpdateWithMD contains the raw message of the update and the metadata,
+// including version, raw message, timestamp.
+//
+// This is to be used for config dump and CSDS, not directly by users (like
+// resolvers/balancers).
+type UpdateWithMD struct {
+	MD  UpdateMetadata
+	Raw *anypb.Any
+}

--- a/xds/internal/clients/xdsclient/internal/xdsresource/version.go
+++ b/xds/internal/clients/xdsclient/internal/xdsresource/version.go
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package xdsresource defines constants to distinguish between supported xDS
+// API versions.
+package xdsresource
+
+// Resource URLs. We need to be able to accept either version of the resource
+// regardless of the version of the transport protocol in use.
+const (
+	googleapiPrefix = "type.googleapis.com/"
+
+	V3ListenerType    = "envoy.config.listener.v3.Listener"
+	V3RouteConfigType = "envoy.config.route.v3.RouteConfiguration"
+	V3ClusterType     = "envoy.config.cluster.v3.Cluster"
+	V3EndpointsType   = "envoy.config.endpoint.v3.ClusterLoadAssignment"
+
+	V3ResourceWrapperURL      = googleapiPrefix + "envoy.service.discovery.v3.Resource"
+	V3ListenerURL             = googleapiPrefix + V3ListenerType
+	V3RouteConfigURL          = googleapiPrefix + V3RouteConfigType
+	V3ClusterURL              = googleapiPrefix + V3ClusterType
+	V3EndpointsURL            = googleapiPrefix + V3EndpointsType
+	V3HTTPConnManagerURL      = googleapiPrefix + "envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+	V3UpstreamTLSContextURL   = googleapiPrefix + "envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext"
+	V3DownstreamTLSContextURL = googleapiPrefix + "envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext"
+)

--- a/xds/internal/clients/xdsclient/resource_type.go
+++ b/xds/internal/clients/xdsclient/resource_type.go
@@ -1,0 +1,92 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsclient
+
+// ResourceType wraps all resource-type specific functionality. Each supported
+// resource type needs to provide an implementation of the Decoder.
+type ResourceType struct {
+	// TypeURL is the xDS type URL of this resource type for the v3 xDS
+	// protocol. This URL is used as the key to look up the corresponding
+	// ResourceType implementation in the ResourceTypes map provided in the
+	// Config.
+	TypeURL string
+
+	// TODO: Revisit if we need TypeURL to be part of the struct because it is
+	// already a key in config's ResouceTypes map.
+
+	// TypeName is a shorter representation of the TypeURL to identify the
+	// resource type. It is used for logging/debugging purposes.
+	TypeName string
+
+	// AllResourcesRequiredInSotW indicates whether this resource type requires
+	// that all resources be present in every SotW response from the server. If
+	// true, a response that does not include a previously seen resource will
+	// be interpreted as a deletion of that resource.
+	AllResourcesRequiredInSotW bool
+
+	// Decoder is used to deserialize and validate an xDS resource received
+	// from the xDS management server.
+	Decoder Decoder
+}
+
+// Decoder wraps the resource-type specific functionality for validation
+// and deserialization.
+type Decoder interface {
+	// Decode deserializes and validates an xDS resource as received from the
+	// xDS management server.
+	//
+	// If deserialization fails or resource validation fails, it returns a
+	// non-nil error. Otherwise, returns a fully populated DecodeResult.
+	Decode(resource []byte, options DecodeOptions) (*DecodeResult, error)
+}
+
+// DecodeOptions wraps the options required by ResourceType implementations for
+// decoding configuration received from the xDS management server.
+type DecodeOptions struct {
+	// Config contains the complete configuration passed to the xDS client.
+	// This contains useful data for resource validation.
+	Config *Config
+
+	// ServerConfig contains the configuration of the xDS server that provided
+	// the current resource being decoded.
+	ServerConfig *ServerConfig
+}
+
+// DecodeResult is the result of a decode operation.
+type DecodeResult struct {
+	// Name is the name of the decoded resource.
+	Name string
+
+	// Resource contains the configuration associated with the decoded
+	// resource.
+	Resource ResourceData
+}
+
+// ResourceData contains the configuration data sent by the xDS management
+// server, associated with the resource being watched. Every resource type must
+// provide an implementation of this interface to represent the configuration
+// received from the xDS management server.
+type ResourceData interface {
+	// RawEqual returns true if the passed in resource data is equal to that of
+	// the receiver, based on the underlying raw message.
+	RawEqual(ResourceData) bool
+
+	// Raw returns the underlying raw form of the resource.
+	Raw() []byte
+}

--- a/xds/internal/clients/xdsclient/resource_watcher.go
+++ b/xds/internal/clients/xdsclient/resource_watcher.go
@@ -1,0 +1,45 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsclient
+
+// ResourceWatcher is notified of the resource updates and errors that are
+// received by the xDS client from the management server.
+//
+// All methods contain a done parameter which should be called when processing
+// of the update has completed.  For example, if processing a resource requires
+// watching new resources, those watches should be completed before done is
+// called, which can happen after the ResourceWatcher method has returned.
+// Failure to call done will prevent the xDS client from providing future
+// ResourceWatcher notifications.
+type ResourceWatcher interface {
+	// ResourceChanged indicates a new version of the resource is available.
+	ResourceChanged(resourceData ResourceData, done func())
+
+	// ResourceError indicates an error occurred while trying to fetch or
+	// decode the associated resource. The previous version of the resource
+	// should be considered invalid.
+	ResourceError(err error, done func())
+
+	// AmbientError indicates an error occurred after a resource has been
+	// received that should not modify the use of that resource but may provide
+	// useful information about the state of the XDSClient for debugging
+	// purposes. The previous version of the resource should still be
+	// considered valid.
+	AmbientError(err error, done func())
+}

--- a/xds/internal/clients/xdsclient/xdsclient.go
+++ b/xds/internal/clients/xdsclient/xdsclient.go
@@ -1,0 +1,67 @@
+//revive:disable:unused-parameter
+
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package xdsclient provides an xDS (* Discovery Service) client.
+//
+// It allows applications to:
+//   - Create xDS client instances with in-memory configurations.
+//   - Register watches for named resources.
+//   - Receive resources via an ADS (Aggregated Discovery Service) stream.
+//   - Register watches for named resources (e.g. listeners, routes, or
+//     clusters).
+//
+// This enables applications to dynamically discover and configure resources
+// such as listeners, routes, clusters, and endpoints from an xDS management
+// server.
+package xdsclient
+
+// XDSClient is a client which queries a set of discovery APIs (collectively
+// termed as xDS) on a remote management server, to discover
+// various dynamic resources.
+type XDSClient struct {
+}
+
+// New returns a new xDS Client configured with the provided config.
+func New(config Config) (*XDSClient, error) {
+	panic("unimplemented")
+}
+
+// WatchResource starts watching the specified resource.
+//
+// typeURL specifies the resource type implementation to use. The watch fails
+// if there is no resource type implementation for the given typeURL. See the
+// ResourceTypes field in the Config struct used to create the XDSClient.
+//
+// The returned function cancels the watch and prevents future calls to the
+// watcher.
+func (c *XDSClient) WatchResource(typeURL, name string, watcher ResourceWatcher) (cancel func()) {
+	panic("unimplemented")
+}
+
+// Close closes the xDS client.
+func (c *XDSClient) Close() error {
+	panic("unimplemented")
+}
+
+// DumpResources returns the status and contents of all xDS resources being
+// watched by the xDS client.
+func (c *XDSClient) DumpResources() []byte {
+	panic("unimplemented")
+}

--- a/xds/internal/clients/xdsclient/xdsclient/channel.go
+++ b/xds/internal/clients/xdsclient/xdsclient/channel.go
@@ -1,0 +1,317 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package xdsclient contains implementation of the xDS client.
+package xdsclient
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc/xds/internal/clients"
+	"google.golang.org/grpc/xds/internal/clients/clientslog"
+	"google.golang.org/grpc/xds/internal/clients/internal/backoff"
+	iclientslog "google.golang.org/grpc/xds/internal/clients/internal/clientslog"
+	"google.golang.org/grpc/xds/internal/clients/internal/clientssync"
+	"google.golang.org/grpc/xds/internal/clients/internal/clientsutils"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/ads"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/xdsresource"
+)
+
+const (
+	clientFeatureNoOverprovisioning = "envoy.lb.does_not_support_overprovisioning"
+	clientFeatureResourceWrapper    = "xds.config.resource-in-sotw"
+)
+
+// xdsChannelEventHandler wraps callbacks used to notify the xDS client about
+// events on the xdsChannel. Methods in this interface may be invoked
+// concurrently and the xDS client implementation needs to handle them in a
+// thread-safe manner.
+type xdsChannelEventHandler interface {
+	// adsStreamFailure is called when the xdsChannel encounters an ADS stream
+	// failure.
+	adsStreamFailure(error)
+
+	// adsResourceUpdate is called when the xdsChannel receives an ADS response
+	// from the xDS management server. The callback is provided with the
+	// following:
+	//   - the resource type of the resources in the response
+	//   - a map of resources in the response, keyed by resource name
+	//   - the metadata associated with the response
+	//   - a callback to be invoked when the updated is processed
+	adsResourceUpdate(xdsclient.ResourceType, map[string]ads.DataAndErrTuple, xdsresource.UpdateMetadata, func())
+
+	// adsResourceDoesNotExist is called when the xdsChannel determines that a
+	// requested ADS resource does not exist.
+	adsResourceDoesNotExist(xdsclient.ResourceType, string)
+}
+
+// xdsChannelOpts holds the options for creating a new xdsChannel.
+type xdsChannelOpts struct {
+	transport          clients.Transport                   // Takes ownership of this transport.
+	serverConfig       *xdsclient.ServerConfig             // Configuration of the server to connect to.
+	xdsClientConfig    *xdsclient.Config                   // Complete xDS client configuration, used to decode resources.
+	resourceTypeGetter func(string) xdsclient.ResourceType // Function to retrieve resource parsing functionality, based on resource type.
+	eventHandler       xdsChannelEventHandler              // Callbacks for ADS stream events.
+	backoff            func(int) time.Duration             // Backoff function to use for stream retries. Defaults to exponential backoff, if unset.
+	watchExpiryTimeout time.Duration                       // Timeout for ADS resource watch expiry.
+	logPrefix          string                              // Prefix to use for logging.
+}
+
+// newXDSChannel creates a new xdsChannel instance with the provided options.
+// It performs basic validation on the provided options and initializes the
+// xdsChannel with the necessary components.
+func newXDSChannel(opts xdsChannelOpts) (*xdsChannel, error) {
+	switch {
+	case opts.transport == nil:
+		return nil, errors.New("xdsChannel: transport is nil")
+	case opts.serverConfig == nil:
+		return nil, errors.New("xdsChannel: serverConfig is nil")
+	case opts.xdsClientConfig == nil:
+		return nil, errors.New("xdsChannel: xdsClientConfig is nil")
+	case opts.resourceTypeGetter == nil:
+		return nil, errors.New("xdsChannel: resourceTypeGetter is nil")
+	case opts.eventHandler == nil:
+		return nil, errors.New("xdsChannel: eventHandler is nil")
+	}
+
+	xc := &xdsChannel{
+		transport:          opts.transport,
+		serverConfig:       opts.serverConfig,
+		xdsClientConfig:    opts.xdsClientConfig,
+		resourceTypeGetter: opts.resourceTypeGetter,
+		eventHandler:       opts.eventHandler,
+		closed:             clientssync.NewEvent(),
+	}
+
+	l := clientslog.Component("xds")
+	logPrefix := opts.logPrefix + fmt.Sprintf("[xds-channel %p] ", xc)
+	xc.logger = iclientslog.NewPrefixLogger(l, logPrefix)
+
+	if opts.backoff == nil {
+		opts.backoff = backoff.DefaultExponential.Backoff
+	}
+	xc.ads = ads.NewStreamImpl(ads.StreamOpts{
+		Transport:          xc.transport,
+		EventHandler:       xc,
+		Backoff:            opts.backoff,
+		NodeProto:          clientsutils.NodeProto(opts.xdsClientConfig.Node, []string{clientFeatureNoOverprovisioning, clientFeatureResourceWrapper}),
+		WatchExpiryTimeout: opts.watchExpiryTimeout,
+		LogPrefix:          logPrefix,
+	})
+	return xc, nil
+}
+
+// xdsChannel represents a client channel to a management server, and is
+// responsible for managing the lifecycle of the ADS and LRS streams. It invokes
+// callbacks on the registered event handler for various ADS stream events.
+type xdsChannel struct {
+	// The following fields are initialized at creation time and are read-only
+	// after that, and hence need not be guarded by a mutex.
+	transport          clients.Transport                   // Takes ownership of this transport (used to make streaming calls).
+	ads                *ads.StreamImpl                     // An ADS stream to the management server.
+	serverConfig       *xdsclient.ServerConfig             // Configuration of the server to connect to.
+	xdsClientConfig    *xdsclient.Config                   // Complete xDS client configuration, used to decode resources.
+	resourceTypeGetter func(string) xdsclient.ResourceType // Function to retrieve resource parsing functionality, based on resource type.
+	eventHandler       xdsChannelEventHandler              // Callbacks for ADS stream events.
+	logger             *iclientslog.PrefixLogger           // Logger to use for logging.
+	closed             *clientssync.Event                  // Fired when the channel is closed.
+}
+
+func (xc *xdsChannel) close() {
+	xc.closed.Fire()
+	xc.ads.Stop()
+	xc.transport.Close()
+	xc.logger.Infof("Shutdown")
+}
+
+// subscribe adds a subscription for the given resource name of the given
+// resource type on the ADS stream.
+func (xc *xdsChannel) subscribe(typ xdsclient.ResourceType, name string) {
+	if xc.closed.HasFired() {
+		if xc.logger.V(2) {
+			xc.logger.Infof("Attempt to subscribe to an xDS resource of type %s and name %q on a closed channel", typ.TypeName, name)
+		}
+		return
+	}
+	xc.ads.Subscribe(typ, name)
+}
+
+// unsubscribe removes the subscription for the given resource name of the given
+// resource type from the ADS stream.
+func (xc *xdsChannel) unsubscribe(typ xdsclient.ResourceType, name string) {
+	if xc.closed.HasFired() {
+		if xc.logger.V(2) {
+			xc.logger.Infof("Attempt to unsubscribe to an xDS resource of type %s and name %q on a closed channel", typ.TypeName, name)
+		}
+		return
+	}
+	xc.ads.Unsubscribe(typ, name)
+}
+
+// The following OnADSXxx() methods implement the ads.StreamEventHandler interface
+// and are invoked by the ADS stream implementation.
+
+// OnADSStreamError is invoked when an error occurs on the ADS stream. It
+// propagates the update to the xDS client.
+func (xc *xdsChannel) OnADSStreamError(err error) {
+	if xc.closed.HasFired() {
+		if xc.logger.V(2) {
+			xc.logger.Infof("Received ADS stream error on a closed xdsChannel: %v", err)
+		}
+		return
+	}
+	xc.eventHandler.adsStreamFailure(err)
+}
+
+// OnADSWatchExpiry is invoked when a watch for a resource expires. It
+// propagates the update to the xDS client.
+func (xc *xdsChannel) OnADSWatchExpiry(typ xdsclient.ResourceType, name string) {
+	if xc.closed.HasFired() {
+		if xc.logger.V(2) {
+			xc.logger.Infof("Received ADS resource watch expiry for resource %q on a closed xdsChannel", name)
+		}
+		return
+	}
+	xc.eventHandler.adsResourceDoesNotExist(typ, name)
+}
+
+// OnADSResponse is invoked when a response is received on the ADS stream. It
+// decodes the resources in the response, and propagates the updates to the xDS
+// client.
+//
+// It returns the list of resource names in the response and any errors
+// encountered during decoding.
+func (xc *xdsChannel) OnADSResponse(resp ads.Response, onDone func()) ([]string, error) {
+	if xc.closed.HasFired() {
+		if xc.logger.V(2) {
+			xc.logger.Infof("Received an update from the ADS stream on closed ADS stream")
+		}
+		return nil, errors.New("xdsChannel is closed")
+	}
+
+	// Lookup the resource parser based on the resource type.
+	rType := xc.resourceTypeGetter(resp.TypeURL)
+	if rType.Decoder == nil {
+		return nil, xdsresource.NewErrorf(xdsresource.ErrorTypeResourceTypeUnsupported, "Resource type URL %q unknown in response from server", resp.TypeURL)
+	}
+
+	// Decode the resources and build the list of resource names to return.
+	opts := &xdsclient.DecodeOptions{
+		Config:       xc.xdsClientConfig,
+		ServerConfig: xc.serverConfig,
+	}
+	updates, md, err := decodeResponse(opts, &rType, resp)
+	var names []string
+	for name := range updates {
+		names = append(names, name)
+	}
+
+	xc.eventHandler.adsResourceUpdate(rType, updates, md, onDone)
+	return names, err
+}
+
+// decodeResponse decodes the resources in the given ADS response.
+//
+// The opts parameter provides configuration options for decoding the resources.
+// The rType parameter specifies the resource type parser to use for decoding
+// the resources.
+//
+// The returned map contains a key for each resource in the response, with the
+// value being either the decoded resource data or an error if decoding failed.
+// The returned metadata includes the version of the response, the timestamp of
+// the update, and the status of the update (ACKed or NACKed).
+//
+// If there are any errors decoding the resources, the metadata will indicate
+// that the update was NACKed, and the returned error will contain information
+// about all errors encountered by this function.
+func decodeResponse(opts *xdsclient.DecodeOptions, rType *xdsclient.ResourceType, resp ads.Response) (map[string]ads.DataAndErrTuple, xdsresource.UpdateMetadata, error) {
+	timestamp := time.Now()
+	md := xdsresource.UpdateMetadata{
+		Version:   resp.Version,
+		Timestamp: timestamp,
+	}
+
+	topLevelErrors := make([]error, 0)          // Tracks deserialization errors, where we don't have a resource name.
+	perResourceErrors := make(map[string]error) // Tracks resource validation errors, where we have a resource name.
+	ret := make(map[string]ads.DataAndErrTuple) // Return result, a map from resource name to either resource data or error.
+	for _, r := range resp.Resources {
+		result, err := rType.Decoder.Decode(r.GetValue(), *opts)
+
+		// Name field of the result is left unpopulated only when resource
+		// deserialization fails.
+		name := ""
+		if result != nil {
+			name = xdsresource.ParseName(result.Name).String()
+		}
+		if err == nil {
+			ret[name] = ads.DataAndErrTuple{Resource: result.Resource}
+			continue
+		}
+		if name == "" {
+			topLevelErrors = append(topLevelErrors, err)
+			continue
+		}
+		perResourceErrors[name] = err
+		// Add place holder in the map so we know this resource name was in
+		// the response.
+		ret[name] = ads.DataAndErrTuple{Err: err}
+	}
+
+	if len(topLevelErrors) == 0 && len(perResourceErrors) == 0 {
+		md.Status = xdsresource.ServiceStatusACKed
+		return ret, md, nil
+	}
+
+	md.Status = xdsresource.ServiceStatusNACKed
+	errRet := combineErrors(rType.TypeName, topLevelErrors, perResourceErrors)
+	md.ErrState = &xdsresource.UpdateErrorMetadata{
+		Version:   resp.Version,
+		Err:       errRet,
+		Timestamp: timestamp,
+	}
+	return ret, md, errRet
+}
+
+func combineErrors(rType string, topLevelErrors []error, perResourceErrors map[string]error) error {
+	var errStrB strings.Builder
+	errStrB.WriteString(fmt.Sprintf("error parsing %q response: ", rType))
+	if len(topLevelErrors) > 0 {
+		errStrB.WriteString("top level errors: ")
+		for i, err := range topLevelErrors {
+			if i != 0 {
+				errStrB.WriteString(";\n")
+			}
+			errStrB.WriteString(err.Error())
+		}
+	}
+	if len(perResourceErrors) > 0 {
+		var i int
+		for name, err := range perResourceErrors {
+			if i != 0 {
+				errStrB.WriteString(";\n")
+			}
+			i++
+			errStrB.WriteString(fmt.Sprintf("resource %q: %v", name, err.Error()))
+		}
+	}
+	return errors.New(errStrB.String())
+}

--- a/xds/internal/clients/xdsclient/xdsclient/channel_test.go
+++ b/xds/internal/clients/xdsclient/xdsclient/channel_test.go
@@ -1,0 +1,926 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
+
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/internal/grpctest"
+	"google.golang.org/grpc/internal/testutils"
+
+	"google.golang.org/grpc/xds/internal/clients"
+	"google.golang.org/grpc/xds/internal/clients/grpctransport"
+	"google.golang.org/grpc/xds/internal/clients/internal/testutils/e2e"
+	"google.golang.org/grpc/xds/internal/clients/internal/testutils/fakeserver"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/ads"
+	xdsclienttestutils "google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/httpfilter"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/testutils/httpfilter/router"
+	"google.golang.org/grpc/xds/internal/clients/xdsclient/internal/xdsresource"
+
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	v3corepb "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	v3listenerpb "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	v3routepb "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	v3routerpb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	v3httppb "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	v3discoverypb "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+)
+
+type s struct {
+	grpctest.Tester
+}
+
+func Test(t *testing.T) {
+	grpctest.RunSubTests(t, s{})
+}
+
+const (
+	defaultTestWatchExpiryTimeout = 100 * time.Millisecond
+	defaultTestTimeout            = 5 * time.Second
+	defaultTestShortTimeout       = 10 * time.Millisecond // For events expected to *not* happen.
+)
+
+// Lookup the listener resource type from the resource type map. This is used to
+// parse listener resources used in this test.
+var listenerType = xdsclienttestutils.ResourceTypeMapForTesting[xdsresource.V3ListenerURL].(xdsclient.ResourceType)
+
+// xdsChannelForTest creates an xdsChannel to the specified serverURI for
+// testing purposes.
+func xdsChannelForTest(t *testing.T, serverURI, nodeID string, watchExpiryTimeout time.Duration) *xdsChannel {
+	t.Helper()
+
+	// Create a grpc transport to the above management server.
+	si := clients.ServerIdentifier{
+		ServerURI:  serverURI,
+		Extensions: grpctransport.ServerIdentifierExtension{Credentials: insecure.NewBundle()},
+	}
+	tr, err := (&grpctransport.Builder{}).Build(si)
+	if err != nil {
+		t.Fatalf("Failed to create a transport for server config %v: %v", si, err)
+	}
+
+	serverCfg := xdsclient.ServerConfig{
+		ServerIdentifier: si,
+	}
+	xdsClientConfig := xdsclient.Config{
+		Servers: []xdsclient.ServerConfig{serverCfg},
+		Node:    clients.Node{ID: nodeID},
+	}
+	// Create an xdsChannel that uses everything set up above.
+	xc, err := newXDSChannel(xdsChannelOpts{
+		transport:       tr,
+		serverConfig:    &serverCfg,
+		xdsClientConfig: &xdsClientConfig,
+		resourceTypeGetter: func(typeURL string) xdsclient.ResourceType {
+			if typeURL != "type.googleapis.com/envoy.config.listener.v3.Listener" {
+				return xdsclient.ResourceType{}
+			}
+			return listenerType
+		},
+		eventHandler:       newTestEventHandler(),
+		watchExpiryTimeout: watchExpiryTimeout,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create xdsChannel: %v", err)
+	}
+	t.Cleanup(func() { xc.close() })
+	return xc
+}
+
+// verifyUpdateAndMetadata verifies that the event handler received the expected
+// updates and metadata.  It checks that the received resource type matches the
+// expected type, and that the received updates and metadata match the expected
+// values. The function ignores the timestamp fields in the metadata, as those
+// are expected to be different.
+func verifyUpdateAndMetadata(ctx context.Context, t *testing.T, eh *testEventHandler, wantUpdates map[string]ads.DataAndErrTuple, wantMD xdsresource.UpdateMetadata) {
+	t.Helper()
+
+	gotTyp, gotUpdates, gotMD, err := eh.waitForUpdate(ctx)
+	if err != nil {
+		t.Fatalf("Timeout when waiting for update callback to be invoked on the event handler")
+	}
+
+	if gotTyp != listenerType {
+		t.Fatalf("Got resource type %v, want %v", gotTyp, listenerType)
+	}
+	opts := cmp.Options{
+		protocmp.Transform(),
+		cmpopts.EquateEmpty(),
+		cmpopts.EquateErrors(),
+		cmpopts.IgnoreFields(xdsresource.UpdateMetadata{}, "Timestamp"),
+		cmpopts.IgnoreFields(xdsresource.UpdateErrorMetadata{}, "Timestamp"),
+	}
+	if diff := cmp.Diff(wantUpdates, gotUpdates, opts); diff != "" {
+		t.Fatalf("Got unexpected diff in update (-want +got):\n%s\n want: %+v\n got: %+v", diff, wantUpdates, gotUpdates)
+	}
+	if diff := cmp.Diff(wantMD, gotMD, opts); diff != "" {
+		t.Fatalf("Got unexpected diff in update (-want +got):\n%s\n want: %v\n got: %v", diff, wantMD, gotMD)
+	}
+}
+
+// Tests different failure cases when creating a new xdsChannel. It checks that
+// the xdsChannel creation fails when any of the required options (transport,
+// serverConfig, bootstrapConfig, or resourceTypeGetter) are missing or nil.
+func (s) TestChannel_New_FailureCases(t *testing.T) {
+	type fakeTransport struct {
+		clients.Transport
+	}
+
+	tests := []struct {
+		name       string
+		opts       xdsChannelOpts
+		wantErrStr string
+	}{
+		{
+			name:       "emptyTransport",
+			opts:       xdsChannelOpts{},
+			wantErrStr: "transport is nil",
+		},
+		{
+			name:       "emptyServerConfig",
+			opts:       xdsChannelOpts{transport: &fakeTransport{}},
+			wantErrStr: "serverConfig is nil",
+		},
+		{
+			name: "emptyBootstrapConfig",
+			opts: xdsChannelOpts{
+				transport:    &fakeTransport{},
+				serverConfig: &xdsclient.ServerConfig{},
+			},
+			wantErrStr: "xdsClientConfig is nil",
+		},
+		{
+			name: "emptyResourceTypeGetter",
+			opts: xdsChannelOpts{
+				transport:       &fakeTransport{},
+				serverConfig:    &xdsclient.ServerConfig{},
+				xdsClientConfig: &xdsclient.Config{},
+			},
+			wantErrStr: "resourceTypeGetter is nil",
+		},
+		{
+			name: "emptyEventHandler",
+			opts: xdsChannelOpts{
+				transport:          &fakeTransport{},
+				serverConfig:       &xdsclient.ServerConfig{},
+				xdsClientConfig:    &xdsclient.Config{},
+				resourceTypeGetter: func(string) xdsclient.ResourceType { return xdsclient.ResourceType{} },
+			},
+			wantErrStr: "eventHandler is nil",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := newXDSChannel(test.opts); err == nil || !strings.Contains(err.Error(), test.wantErrStr) {
+				t.Fatalf("newXDSChannel() = %v, want %q", err, test.wantErrStr)
+			}
+		})
+	}
+}
+
+// Tests different scenarios of the xdsChannel receiving a response from the
+// management server. In all scenarios, the xdsChannel is expected to pass the
+// received responses as-is to the resource parsing functionality specified by
+// the resourceTypeGetter.
+func (s) TestChannel_ADS_HandleResponseFromManagementServer(t *testing.T) {
+	const (
+		listenerName1 = "listener-name-1"
+		listenerName2 = "listener-name-2"
+		routeName     = "route-name"
+		clusterName   = "cluster-name"
+	)
+	var (
+		badlyMarshaledResource = &anypb.Any{
+			TypeUrl: "type.googleapis.com/envoy.config.listener.v3.Listener",
+			Value:   []byte{1, 2, 3, 4},
+		}
+		apiListener = &v3listenerpb.ApiListener{
+			ApiListener: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+				RouteSpecifier: &v3httppb.HttpConnectionManager_RouteConfig{
+					RouteConfig: &v3routepb.RouteConfiguration{
+						Name: routeName,
+						VirtualHosts: []*v3routepb.VirtualHost{{
+							Domains: []string{"*"},
+							Routes: []*v3routepb.Route{{
+								Match: &v3routepb.RouteMatch{
+									PathSpecifier: &v3routepb.RouteMatch_Prefix{Prefix: "/"},
+								},
+								Action: &v3routepb.Route_Route{
+									Route: &v3routepb.RouteAction{
+										ClusterSpecifier: &v3routepb.RouteAction_Cluster{Cluster: clusterName},
+									}}}}}}},
+				},
+				HttpFilters: []*v3httppb.HttpFilter{e2e.RouterHTTPFilter},
+				CommonHttpProtocolOptions: &v3corepb.HttpProtocolOptions{
+					MaxStreamDuration: durationpb.New(time.Second),
+				},
+			}),
+		}
+		listener1 = testutils.MarshalAny(t, &v3listenerpb.Listener{
+			Name:        listenerName1,
+			ApiListener: apiListener,
+		})
+		listener2 = testutils.MarshalAny(t, &v3listenerpb.Listener{
+			Name:        listenerName2,
+			ApiListener: apiListener,
+		})
+	)
+
+	tests := []struct {
+		desc                     string
+		resourceNamesToRequest   []string
+		managementServerResponse *v3discoverypb.DiscoveryResponse
+		wantUpdates              map[string]ads.DataAndErrTuple
+		wantMD                   xdsresource.UpdateMetadata
+		wantErr                  error
+	}{
+		{
+			desc:                   "one bad resource - deserialization failure",
+			resourceNamesToRequest: []string{listenerName1},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				VersionInfo: "0",
+				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources:   []*anypb.Any{badlyMarshaledResource},
+			},
+			wantUpdates: nil, // No updates expected as the response runs into unmarshaling errors.
+			wantMD: xdsresource.UpdateMetadata{
+				Status:  xdsresource.ServiceStatusNACKed,
+				Version: "0",
+				ErrState: &xdsresource.UpdateErrorMetadata{
+					Version: "0",
+					Err:     cmpopts.AnyError,
+				},
+			},
+			wantErr: cmpopts.AnyError,
+		},
+		{
+			desc:                   "one bad resource - validation failure",
+			resourceNamesToRequest: []string{listenerName1},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				VersionInfo: "0",
+				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources: []*anypb.Any{testutils.MarshalAny(t, &v3listenerpb.Listener{
+					Name: listenerName1,
+					ApiListener: &v3listenerpb.ApiListener{
+						ApiListener: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+							RouteSpecifier: &v3httppb.HttpConnectionManager_ScopedRoutes{},
+						}),
+					},
+				})},
+			},
+			wantUpdates: map[string]ads.DataAndErrTuple{
+				listenerName1: {
+					Err: cmpopts.AnyError,
+				},
+			},
+			wantMD: xdsresource.UpdateMetadata{
+				Status:  xdsresource.ServiceStatusNACKed,
+				Version: "0",
+				ErrState: &xdsresource.UpdateErrorMetadata{
+					Version: "0",
+					Err:     cmpopts.AnyError,
+				},
+			},
+		},
+		{
+			desc:                   "two bad resources",
+			resourceNamesToRequest: []string{listenerName1, listenerName2},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				VersionInfo: "0",
+				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources: []*anypb.Any{
+					badlyMarshaledResource,
+					testutils.MarshalAny(t, &v3listenerpb.Listener{
+						Name: listenerName2,
+						ApiListener: &v3listenerpb.ApiListener{
+							ApiListener: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_ScopedRoutes{},
+							}),
+						},
+					}),
+				},
+			},
+			wantUpdates: map[string]ads.DataAndErrTuple{
+				listenerName2: {
+					Err: cmpopts.AnyError,
+				},
+			},
+			wantMD: xdsresource.UpdateMetadata{
+				Status:  xdsresource.ServiceStatusNACKed,
+				Version: "0",
+				ErrState: &xdsresource.UpdateErrorMetadata{
+					Version: "0",
+					Err:     cmpopts.AnyError,
+				},
+			},
+		},
+		{
+			desc:                   "one good resource",
+			resourceNamesToRequest: []string{listenerName1},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				VersionInfo: "0",
+				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources:   []*anypb.Any{listener1},
+			},
+			wantUpdates: map[string]ads.DataAndErrTuple{
+				listenerName1: {
+					Resource: &xdsclienttestutils.ListenerResourceData{Resource: xdsclienttestutils.ListenerUpdate{
+						InlineRouteConfig: &xdsclienttestutils.RouteConfigUpdate{
+							VirtualHosts: []*xdsclienttestutils.VirtualHost{{
+								Domains: []string{"*"},
+								Routes: []*xdsclienttestutils.Route{{
+									Prefix:           newStringP("/"),
+									WeightedClusters: map[string]xdsclienttestutils.WeightedCluster{clusterName: {Weight: 1}},
+									ActionType:       xdsclienttestutils.RouteActionRoute},
+								},
+							}}},
+						MaxStreamDuration: time.Second,
+						Raw:               listener1.GetValue(),
+						HTTPFilters:       makeRouterFilterList(t),
+					}},
+				},
+			},
+			wantMD: xdsresource.UpdateMetadata{
+				Status:  xdsresource.ServiceStatusACKed,
+				Version: "0",
+			},
+		},
+		{
+			desc:                   "one good and one bad - deserialization failure",
+			resourceNamesToRequest: []string{listenerName1, listenerName2},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				VersionInfo: "0",
+				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources: []*anypb.Any{
+					badlyMarshaledResource,
+					listener2,
+				},
+			},
+			wantUpdates: map[string]ads.DataAndErrTuple{
+				listenerName2: {
+					Resource: &xdsclienttestutils.ListenerResourceData{Resource: xdsclienttestutils.ListenerUpdate{
+						InlineRouteConfig: &xdsclienttestutils.RouteConfigUpdate{
+							VirtualHosts: []*xdsclienttestutils.VirtualHost{{
+								Domains: []string{"*"},
+								Routes: []*xdsclienttestutils.Route{{
+									Prefix:           newStringP("/"),
+									WeightedClusters: map[string]xdsclienttestutils.WeightedCluster{clusterName: {Weight: 1}},
+									ActionType:       xdsclienttestutils.RouteActionRoute},
+								},
+							}}},
+						MaxStreamDuration: time.Second,
+						Raw:               listener2.GetValue(),
+						HTTPFilters:       makeRouterFilterList(t),
+					}},
+				},
+			},
+			wantMD: xdsresource.UpdateMetadata{
+				Status:  xdsresource.ServiceStatusNACKed,
+				Version: "0",
+				ErrState: &xdsresource.UpdateErrorMetadata{
+					Version: "0",
+					Err:     cmpopts.AnyError,
+				},
+			},
+		},
+		{
+			desc:                   "one good and one bad - validation failure",
+			resourceNamesToRequest: []string{listenerName1, listenerName2},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				VersionInfo: "0",
+				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources: []*anypb.Any{
+					testutils.MarshalAny(t, &v3listenerpb.Listener{
+						Name: listenerName1,
+						ApiListener: &v3listenerpb.ApiListener{
+							ApiListener: testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+								RouteSpecifier: &v3httppb.HttpConnectionManager_ScopedRoutes{},
+							}),
+						},
+					}),
+					listener2,
+				},
+			},
+			wantUpdates: map[string]ads.DataAndErrTuple{
+				listenerName1: {Err: cmpopts.AnyError},
+				listenerName2: {
+					Resource: &xdsclienttestutils.ListenerResourceData{Resource: xdsclienttestutils.ListenerUpdate{
+						InlineRouteConfig: &xdsclienttestutils.RouteConfigUpdate{
+							VirtualHosts: []*xdsclienttestutils.VirtualHost{{
+								Domains: []string{"*"},
+								Routes: []*xdsclienttestutils.Route{{
+									Prefix:           newStringP("/"),
+									WeightedClusters: map[string]xdsclienttestutils.WeightedCluster{clusterName: {Weight: 1}},
+									ActionType:       xdsclienttestutils.RouteActionRoute},
+								},
+							}}},
+						MaxStreamDuration: time.Second,
+						Raw:               listener2.GetValue(),
+						HTTPFilters:       makeRouterFilterList(t),
+					}},
+				},
+			},
+			wantMD: xdsresource.UpdateMetadata{
+				Status:  xdsresource.ServiceStatusNACKed,
+				Version: "0",
+				ErrState: &xdsresource.UpdateErrorMetadata{
+					Version: "0",
+					Err:     cmpopts.AnyError,
+				},
+			},
+		},
+		{
+			desc:                   "two good resources",
+			resourceNamesToRequest: []string{listenerName1, listenerName2},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				VersionInfo: "0",
+				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources:   []*anypb.Any{listener1, listener2},
+			},
+			wantUpdates: map[string]ads.DataAndErrTuple{
+				listenerName1: {
+					Resource: &xdsclienttestutils.ListenerResourceData{Resource: xdsclienttestutils.ListenerUpdate{
+						InlineRouteConfig: &xdsclienttestutils.RouteConfigUpdate{
+							VirtualHosts: []*xdsclienttestutils.VirtualHost{{
+								Domains: []string{"*"},
+								Routes: []*xdsclienttestutils.Route{{
+									Prefix:           newStringP("/"),
+									WeightedClusters: map[string]xdsclienttestutils.WeightedCluster{clusterName: {Weight: 1}},
+									ActionType:       xdsclienttestutils.RouteActionRoute},
+								},
+							}}},
+						MaxStreamDuration: time.Second,
+						Raw:               listener1.GetValue(),
+						HTTPFilters:       makeRouterFilterList(t),
+					}},
+				},
+				listenerName2: {
+					Resource: &xdsclienttestutils.ListenerResourceData{Resource: xdsclienttestutils.ListenerUpdate{
+						InlineRouteConfig: &xdsclienttestutils.RouteConfigUpdate{
+							VirtualHosts: []*xdsclienttestutils.VirtualHost{{
+								Domains: []string{"*"},
+								Routes: []*xdsclienttestutils.Route{{
+									Prefix:           newStringP("/"),
+									WeightedClusters: map[string]xdsclienttestutils.WeightedCluster{clusterName: {Weight: 1}},
+									ActionType:       xdsclienttestutils.RouteActionRoute},
+								},
+							}}},
+						MaxStreamDuration: time.Second,
+						Raw:               listener2.GetValue(),
+						HTTPFilters:       makeRouterFilterList(t),
+					}},
+				},
+			},
+			wantMD: xdsresource.UpdateMetadata{
+				Status:  xdsresource.ServiceStatusACKed,
+				Version: "0",
+			},
+		},
+		{
+			desc:                   "two resources when we requested one",
+			resourceNamesToRequest: []string{listenerName1},
+			managementServerResponse: &v3discoverypb.DiscoveryResponse{
+				VersionInfo: "0",
+				TypeUrl:     "type.googleapis.com/envoy.config.listener.v3.Listener",
+				Resources:   []*anypb.Any{listener1, listener2},
+			},
+			wantUpdates: map[string]ads.DataAndErrTuple{
+				listenerName1: {
+					Resource: &xdsclienttestutils.ListenerResourceData{Resource: xdsclienttestutils.ListenerUpdate{
+						InlineRouteConfig: &xdsclienttestutils.RouteConfigUpdate{
+							VirtualHosts: []*xdsclienttestutils.VirtualHost{{
+								Domains: []string{"*"},
+								Routes: []*xdsclienttestutils.Route{{
+									Prefix:           newStringP("/"),
+									WeightedClusters: map[string]xdsclienttestutils.WeightedCluster{clusterName: {Weight: 1}},
+									ActionType:       xdsclienttestutils.RouteActionRoute},
+								},
+							}}},
+						MaxStreamDuration: time.Second,
+						Raw:               listener1.GetValue(),
+						HTTPFilters:       makeRouterFilterList(t),
+					}},
+				},
+				listenerName2: {
+					Resource: &xdsclienttestutils.ListenerResourceData{Resource: xdsclienttestutils.ListenerUpdate{
+						InlineRouteConfig: &xdsclienttestutils.RouteConfigUpdate{
+							VirtualHosts: []*xdsclienttestutils.VirtualHost{{
+								Domains: []string{"*"},
+								Routes: []*xdsclienttestutils.Route{{
+									Prefix:           newStringP("/"),
+									WeightedClusters: map[string]xdsclienttestutils.WeightedCluster{clusterName: {Weight: 1}},
+									ActionType:       xdsclienttestutils.RouteActionRoute},
+								},
+							}}},
+						MaxStreamDuration: time.Second,
+						Raw:               listener2.GetValue(),
+						HTTPFilters:       makeRouterFilterList(t),
+					}},
+				},
+			},
+			wantMD: xdsresource.UpdateMetadata{
+				Status:  xdsresource.ServiceStatusACKed,
+				Version: "0",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout*10000)
+			defer cancel()
+
+			// Start a fake xDS management server and configure the response it
+			// would send to its client.
+			mgmtServer, cleanup, err := fakeserver.StartServer(nil)
+			if err != nil {
+				t.Fatalf("Failed to start fake xDS server: %v", err)
+			}
+			defer cleanup()
+			t.Logf("Started xDS management server on %s", mgmtServer.Address)
+			mgmtServer.XDSResponseChan <- &fakeserver.Response{Resp: test.managementServerResponse}
+
+			// Create an xdsChannel for the test with a long watch expiry timer
+			// to ensure that watches don't expire for the duration of the test.
+			nodeID := uuid.New().String()
+			xc := xdsChannelForTest(t, mgmtServer.Address, nodeID, 2*defaultTestTimeout)
+			defer xc.close()
+
+			// Subscribe to the resources specified in the test table.
+			for _, name := range test.resourceNamesToRequest {
+				xc.subscribe(listenerType, name)
+			}
+
+			// Wait for an update callback on the event handler and verify the
+			// contents of the update and the metadata.
+			verifyUpdateAndMetadata(ctx, t, xc.eventHandler.(*testEventHandler), test.wantUpdates, test.wantMD)
+		})
+	}
+}
+
+// Tests that the xdsChannel correctly handles the expiry of a watch for a
+// resource by ensuring that the watch expiry callback is invoked on the event
+// handler with the expected resource type and name.
+func (s) TestChannel_ADS_HandleResponseWatchExpiry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout*20000)
+	defer cancel()
+
+	// Start an xDS management server, but do not configure any resources on it.
+	// This will result in the watch for a resource to timeout.
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{})
+
+	// Create an xdsChannel for the test with a short watch expiry timer to
+	// ensure that the test does not run very long, as it needs to wait for the
+	// watch to expire.
+	nodeID := uuid.New().String()
+	xc := xdsChannelForTest(t, mgmtServer.Address, nodeID, 2*defaultTestShortTimeout)
+	defer xc.close()
+
+	// Subscribe to a listener resource.
+	const listenerName = "listener-name"
+	xc.subscribe(listenerType, listenerName)
+
+	// Wait for the watch expiry callback on the authority to be invoked and
+	// verify that the watch expired for the expected resource name and type.
+	eventHandler := xc.eventHandler.(*testEventHandler)
+	gotTyp, gotName, err := eventHandler.waitForResourceDoesNotExist(ctx)
+	if err != nil {
+		t.Fatal("Timeout when waiting for the watch expiry callback to be invoked on the xDS client")
+	}
+
+	if gotTyp != listenerType {
+		t.Fatalf("Got type %v, want %v", gotTyp, listenerType)
+	}
+	if gotName != listenerName {
+		t.Fatalf("Got name %v, want %v", gotName, listenerName)
+	}
+}
+
+// Tests that the xdsChannel correctly handles stream failures by ensuring that
+// the stream failure callback is invoked on the event handler.
+func (s) TestChannel_ADS_StreamFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Start an xDS management server with a restartable listener to simulate
+	// connection failures.
+	l, err := testutils.LocalTCPListener()
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+	lis := testutils.NewRestartableListener(l)
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{Listener: lis})
+
+	// Configure a listener resource on the management server.
+	const listenerResourceName = "test-listener-resource"
+	const routeConfigurationName = "test-route-configuration-resource"
+	nodeID := uuid.New().String()
+	resources := e2e.UpdateOptions{
+		NodeID:         nodeID,
+		Listeners:      []*v3listenerpb.Listener{e2e.DefaultClientListener(listenerResourceName, routeConfigurationName)},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	// Create an xdsChannel for the test with a long watch expiry timer
+	// to ensure that watches don't expire for the duration of the test.
+	xc := xdsChannelForTest(t, mgmtServer.Address, nodeID, 2*defaultTestTimeout)
+	defer xc.close()
+
+	// Subscribe to the resource created above.
+	xc.subscribe(listenerType, listenerResourceName)
+
+	// Wait for an update callback on the event handler and verify the
+	// contents of the update and the metadata.
+	hcm := testutils.MarshalAny(t, &v3httppb.HttpConnectionManager{
+		RouteSpecifier: &v3httppb.HttpConnectionManager_Rds{Rds: &v3httppb.Rds{
+			ConfigSource: &v3corepb.ConfigSource{
+				ConfigSourceSpecifier: &v3corepb.ConfigSource_Ads{Ads: &v3corepb.AggregatedConfigSource{}},
+			},
+			RouteConfigName: routeConfigurationName,
+		}},
+		HttpFilters: []*v3httppb.HttpFilter{e2e.HTTPFilter("router", &v3routerpb.Router{})},
+	})
+	listenerResource, err := anypb.New(&v3listenerpb.Listener{
+		Name:        listenerResourceName,
+		ApiListener: &v3listenerpb.ApiListener{ApiListener: hcm},
+		FilterChains: []*v3listenerpb.FilterChain{{
+			Name: "filter-chain-name",
+			Filters: []*v3listenerpb.Filter{{
+				Name:       wellknown.HTTPConnectionManager,
+				ConfigType: &v3listenerpb.Filter_TypedConfig{TypedConfig: hcm},
+			}},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Failed to create listener resource: %v", err)
+	}
+
+	wantUpdates := map[string]ads.DataAndErrTuple{
+		listenerResourceName: {
+			Resource: &xdsclienttestutils.ListenerResourceData{
+				Resource: xdsclienttestutils.ListenerUpdate{
+					RouteConfigName: routeConfigurationName,
+					HTTPFilters:     makeRouterFilterList(t),
+					Raw:             listenerResource.GetValue(),
+				},
+			},
+		},
+	}
+	wantMD := xdsresource.UpdateMetadata{
+		Status:  xdsresource.ServiceStatusACKed,
+		Version: "1",
+	}
+
+	eventHandler := xc.eventHandler.(*testEventHandler)
+	verifyUpdateAndMetadata(ctx, t, eventHandler, wantUpdates, wantMD)
+
+	lis.Stop()
+	if err := eventHandler.waitForStreamFailure(ctx); err != nil {
+		t.Fatalf("Timeout when waiting for the stream failure callback to be invoked on the xDS client: %v", err)
+	}
+}
+
+// Tests the behavior of the xdsChannel when a resource is unsubscribed.
+// Verifies that when a previously subscribed resource is unsubscribed, a
+// request is sent without the previously subscribed resource name.
+func (s) TestChannel_ADS_ResourceUnsubscribe(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTestTimeout)
+	defer cancel()
+
+	// Start an xDS management server that uses a channel to inform the test
+	// about the specific LDS resource names being requested.
+	ldsResourcesCh := make(chan []string, 1)
+	mgmtServer := e2e.StartManagementServer(t, e2e.ManagementServerOptions{
+		OnStreamRequest: func(_ int64, req *v3discoverypb.DiscoveryRequest) error {
+			t.Logf("Received request for resources: %v of type %s", req.GetResourceNames(), req.GetTypeUrl())
+
+			if req.TypeUrl != xdsresource.V3ListenerURL {
+				return fmt.Errorf("unexpected resource type URL: %q", req.TypeUrl)
+			}
+
+			// Make the most recently requested names available to the test.
+			ldsResourcesCh <- req.GetResourceNames()
+			return nil
+		},
+	})
+
+	// Configure two listener resources on the management server.
+	const listenerResourceName1 = "test-listener-resource-1"
+	const routeConfigurationName1 = "test-route-configuration-resource-1"
+	const listenerResourceName2 = "test-listener-resource-2"
+	const routeConfigurationName2 = "test-route-configuration-resource-2"
+	nodeID := uuid.New().String()
+	resources := e2e.UpdateOptions{
+		NodeID: nodeID,
+		Listeners: []*v3listenerpb.Listener{
+			e2e.DefaultClientListener(listenerResourceName1, routeConfigurationName1),
+			e2e.DefaultClientListener(listenerResourceName2, routeConfigurationName2),
+		},
+		SkipValidation: true,
+	}
+	if err := mgmtServer.Update(ctx, resources); err != nil {
+		t.Fatalf("Failed to update management server with resources: %v, err: %v", resources, err)
+	}
+
+	// Create an xdsChannel for the test with a long watch expiry timer
+	// to ensure that watches don't expire for the duration of the test.
+	xc := xdsChannelForTest(t, mgmtServer.Address, nodeID, 2*defaultTestTimeout)
+	defer xc.close()
+
+	// Subscribe to the resources created above and verify that a request is
+	// sent for the same.
+	xc.subscribe(listenerType, listenerResourceName1)
+	xc.subscribe(listenerType, listenerResourceName2)
+	if err := waitForResourceNames(ctx, t, ldsResourcesCh, []string{listenerResourceName1, listenerResourceName2}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the above resources to be ACKed.
+	if err := waitForResourceNames(ctx, t, ldsResourcesCh, []string{listenerResourceName1, listenerResourceName2}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unsubscribe to one of the resources created above, and ensure that the
+	// other resource is still being requested.
+	xc.unsubscribe(listenerType, listenerResourceName1)
+	if err := waitForResourceNames(ctx, t, ldsResourcesCh, []string{listenerResourceName2}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Since the version on the management server for the above resource is not
+	// changed, we will not receive an update from it for the one resource that
+	// we are still requesting.
+
+	// Unsubscribe to the remaining resource, and ensure that no more resources
+	// are being requested.
+	xc.unsubscribe(listenerType, listenerResourceName2)
+	if err := waitForResourceNames(ctx, t, ldsResourcesCh, []string{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// waitForResourceNames waits for the wantNames to be received on namesCh.
+// Returns a non-nil error if the context expires before that.
+func waitForResourceNames(ctx context.Context, t *testing.T, namesCh chan []string, wantNames []string) error {
+	t.Helper()
+
+	var lastRequestedNames []string
+	for ; ; <-time.After(defaultTestShortTimeout) {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for resources %v to be requested from the management server. Last requested resources: %v", wantNames, lastRequestedNames)
+		case gotNames := <-namesCh:
+			if cmp.Equal(gotNames, wantNames, cmpopts.EquateEmpty(), cmpopts.SortSlices(func(s1, s2 string) bool { return s1 < s2 })) {
+				return nil
+			}
+			lastRequestedNames = gotNames
+		}
+	}
+}
+
+// newTestEventHandler creates a new testEventHandler instance with the
+// necessary channels for testing the xdsChannel.
+func newTestEventHandler() *testEventHandler {
+	return &testEventHandler{
+		typeCh:    make(chan xdsclient.ResourceType, 1),
+		updateCh:  make(chan map[string]ads.DataAndErrTuple, 1),
+		mdCh:      make(chan xdsresource.UpdateMetadata, 1),
+		nameCh:    make(chan string, 1),
+		connErrCh: make(chan error, 1),
+	}
+}
+
+// testEventHandler is a struct that implements the xdsChannelEventhandler
+// interface.  It is used to receive events from an xdsChannel, and has multiple
+// channels on which it makes these events available to the test.
+type testEventHandler struct {
+	typeCh    chan xdsclient.ResourceType         // Resource type of an update or resource-does-not-exist error.
+	updateCh  chan map[string]ads.DataAndErrTuple // Resource updates.
+	mdCh      chan xdsresource.UpdateMetadata     // Metadata from an update.
+	nameCh    chan string                         // Name of the non-existent resource.
+	connErrCh chan error                          // Connectivity error.
+
+}
+
+func (ta *testEventHandler) adsStreamFailure(err error) {
+	ta.connErrCh <- err
+}
+
+func (ta *testEventHandler) waitForStreamFailure(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-ta.connErrCh:
+	}
+	return nil
+}
+
+func (ta *testEventHandler) adsResourceUpdate(typ xdsclient.ResourceType, updates map[string]ads.DataAndErrTuple, md xdsresource.UpdateMetadata, onDone func()) {
+	ta.typeCh <- typ
+	ta.updateCh <- updates
+	ta.mdCh <- md
+	onDone()
+}
+
+// waitForUpdate waits for the next resource update event from the xdsChannel.
+// It returns the resource type, the resource updates, and the update metadata.
+// If the context is canceled, it returns an error.
+func (ta *testEventHandler) waitForUpdate(ctx context.Context) (xdsclient.ResourceType, map[string]ads.DataAndErrTuple, xdsresource.UpdateMetadata, error) {
+	var typ xdsclient.ResourceType
+	var updates map[string]ads.DataAndErrTuple
+	var md xdsresource.UpdateMetadata
+
+	select {
+	case typ = <-ta.typeCh:
+	case <-ctx.Done():
+		return xdsclient.ResourceType{}, nil, xdsresource.UpdateMetadata{}, ctx.Err()
+	}
+
+	select {
+	case updates = <-ta.updateCh:
+	case <-ctx.Done():
+		return xdsclient.ResourceType{}, nil, xdsresource.UpdateMetadata{}, ctx.Err()
+	}
+
+	select {
+	case md = <-ta.mdCh:
+	case <-ctx.Done():
+		return xdsclient.ResourceType{}, nil, xdsresource.UpdateMetadata{}, ctx.Err()
+	}
+	return typ, updates, md, nil
+}
+
+func (ta *testEventHandler) adsResourceDoesNotExist(typ xdsclient.ResourceType, name string) {
+	ta.typeCh <- typ
+	ta.nameCh <- name
+}
+
+// waitForResourceDoesNotExist waits for the next resource-does-not-exist event
+// from the xdsChannel. It returns the resource type and the resource name. If
+// the context is canceled, it returns an error.
+func (ta *testEventHandler) waitForResourceDoesNotExist(ctx context.Context) (xdsclient.ResourceType, string, error) {
+	var typ xdsclient.ResourceType
+	var name string
+
+	select {
+	case typ = <-ta.typeCh:
+	case <-ctx.Done():
+		return xdsclient.ResourceType{}, "", ctx.Err()
+	}
+
+	select {
+	case name = <-ta.nameCh:
+	case <-ctx.Done():
+		return xdsclient.ResourceType{}, "", ctx.Err()
+	}
+	return typ, name, nil
+}
+
+func newStringP(s string) *string {
+	return &s
+}
+
+func makeRouterFilter(t *testing.T) xdsclienttestutils.HTTPFilter {
+	routerBuilder := httpfilter.Get(router.TypeURL)
+	routerConfig, _ := routerBuilder.ParseFilterConfig(testutils.MarshalAny(t, &v3routerpb.Router{}))
+	return xdsclienttestutils.HTTPFilter{Name: "router", Filter: routerBuilder, Config: routerConfig}
+}
+
+func makeRouterFilterList(t *testing.T) []xdsclienttestutils.HTTPFilter {
+	return []xdsclienttestutils.HTTPFilter{makeRouterFilter(t)}
+}

--- a/xds/internal/clients/xdsclient/xdsconfig.go
+++ b/xds/internal/clients/xdsclient/xdsconfig.go
@@ -1,0 +1,85 @@
+/*
+ *
+ * Copyright 2025 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package xdsclient
+
+import (
+	"google.golang.org/grpc/xds/internal/clients"
+)
+
+// Config is used to configure an xDS client. After one has been passed to the
+// xDS client's New function, no part of it may be modified. A Config may be
+// reused; the xdsclient package will also not modify it.
+type Config struct {
+	// Servers specifies a list of xDS management servers to connect to. The
+	// order of the servers in this list reflects the order of preference of
+	// the data returned by those servers. The xDS client uses the first
+	// available server from the list.
+	//
+	// See gRFC A71 for more details on fallback behavior when the primary
+	// xDS server is unavailable.
+	//
+	// gRFC A71: https://github.com/grpc/proposal/blob/master/A71-xds-fallback.md
+	Servers []ServerConfig
+
+	// Authorities defines the configuration for each xDS authority.  Federated resources
+	// will be fetched from the servers specified by the corresponding Authority.
+	Authorities map[string]Authority
+
+	// Node is the identity of the xDS client connecting to the xDS
+	// management server.
+	Node clients.Node
+
+	// TransportBuilder is used to create connections to xDS management servers.
+	TransportBuilder clients.TransportBuilder
+
+	// ResourceTypes is a map from resource type URLs to resource type
+	// implementations. Each resource type URL uniquely identifies a specific
+	// kind of xDS resource, and the corresponding resource type implementation
+	// provides logic for parsing, validating, and processing resources of that
+	// type.
+	//
+	// For example: "type.googleapis.com/envoy.config.listener.v3.Listener"
+	ResourceTypes map[string]ResourceType
+}
+
+// ServerConfig contains configuration for an xDS management server.
+type ServerConfig struct {
+	ServerIdentifier clients.ServerIdentifier
+
+	// IgnoreResourceDeletion is a server feature which if set to true,
+	// indicates that resource deletion errors from xDS management servers can
+	// be ignored and cached resource data can be used.
+	//
+	// This will be removed in the future once we implement gRFC A88
+	// and two new fields FailOnDataErrors and
+	// ResourceTimerIsTransientError will be introduced.
+	IgnoreResourceDeletion bool
+
+	// TODO: Link to gRFC A88
+}
+
+// Authority contains configuration for an xDS control plane authority.
+//
+// See: https://www.envoyproxy.io/docs/envoy/latest/xds/core/v3/resource_locator.proto#xds-core-v3-resourcelocator
+type Authority struct {
+	// XDSServers contains the list of server configurations for this authority.
+	//
+	// See Config.Servers for more details.
+	XDSServers []ServerConfig
+}


### PR DESCRIPTION
Copied Implementation (modified to use generic client configs and interfaces)

From | To |
------- | ---------- |
`xds/internal/xdsclient/transport/ads` | `xds/internal/clients/xdsclient/internal/ads` |
`xds/internal/xdsclient/channel.go` | `xds/internal/clients/xdsclient/xdsclient/channel.go` |
`xds/internal/xdsclient/channel_test.go` | `xds/internal/clients/xdsclient/xdsclient/channel_test.go` |

Copied helpers common (mainly for testing and logging. only what is needed)

From | To |
------- | ---------- |
`backoff` | `xds/internal/clients/backoff` |
`grpclog` | `xds/internal/clients/clientslog` |
`internal/backoff` | `xds/internal/clients/internal/backoff` |
`internal/buffer` | `xds/internal/clients/internal/buffer` |
`internal/grpclog` | `xds/internal/clients/clientslog` |
`internal/pretty` | `xds/internal/clients/internal/pretty` |
`internal/testutils/xds/e2e` | `xds/internal/clients/internal/testutils/e2e` |
`internal/testutils/xds/fakeserver` | `xds/internal/clients/internal/testutils/fakeserver` |
`internal/testutils/channel.go` | `xds/internal/clients/internal/testutils/channel.go` |

Copied helpers xdsclient (mainly for testing and logging. only what is needed)

From | To |
------- | ---------- |
`xds/internal/xdsclient/xdsresource/errors.go` | `xds/internal/clients/xdsclient/internal/xdsresource/errors.go` |
`xds/internal/xdsclient/xdsresource/name.go` | `xds/internal/clients/xdsclient/internal/xdsresource/name.go` |
`xds/internal/xdsclient/xdsresource/type.go` | `xds/internal/clients/xdsclient/internal/xdsresource/type.go` |
`xds/internal/xdsclient/xdsresource/version/version.go` | `xds/internal/clients/xdsclient/internal/xdsresource/version.go` |
`internal/grpcutil/metadata.go` | `xds/internal/clients/xdsclient/internal/testutils/clientutils/metadata.go` |
`internal/grpcutil/regex.go` | `xds/internal/clients/xdsclient/internal/testutils/clientutils/regex.go` |
`xds/internal/httpfilter/httpfilter.go` | `xds/internal/clients/xdsclient/internal/testutils/httpfilter/httpfilter.go` |
`xds/internal/httpfilter/router` | `xds/internal/clients/xdsclient/internal/testutils/httpfilter/router` |
`internal/xds/matcher` | `xds/internal/clients/xdsclient/internal/testutils/matcher` |
`internal/resolver/config_selector.go` | `xds/internal/clients/xdsclient/internal/testutils/resolver/interceptor.go` |
`xds/internal/xdsclient/xdsresource/filter_chain.go` | `xds/internal/clients/xdsclient/internal/testutils/filter_chain.go` |
`xds/internal/xdsclient/xdsresource/listener_resource_type.go` | `xds/internal/clients/xdsclient/internal/testutils/listener_resource_type.go` |
`xds/internal/xdsclient/xdsresource/logging.go` | `xds/internal/clients/xdsclient/internal/testutils/logger.go` |
`xds/internal/xdsclient/xdsresource/matcher_path.go` | `xds/internal/clients/xdsclient/internal/testutils/matcher_path.go` |
`xds/internal/xdsclient/xdsresource/matcher.go` | `xds/internal/clients/xdsclient/internal/testutils/matcher.go` |
`xds/internal/xdsclient/xdsresource/type_cds.go` | `xds/internal/clients/xdsclient/internal/testutils/type_cds.go` |
`xds/internal/xdsclient/xdsresource/type_lds.go` | `xds/internal/clients/xdsclient/internal/testutils/type_lds.go` |
`xds/internal/xdsclient/xdsresource/type_rds.go` | `xds/internal/clients/xdsclient/internal/testutils/type_rds.go` |
`xds/internal/xdsclient/xdsresource/type.go` | `xds/internal/clients/xdsclient/internal/testutils/type.go` |
`xds/internal/xdsclient/xdsresource/unmarshal_cds.go` | `xds/internal/clients/xdsclient/internal/testutils/unmarshal_cds.go` |
`xds/internal/xdsclient/xdsresource/unmarshal_lds.go` | `xds/internal/clients/xdsclient/internal/testutils/unmarshal_lds.go` |
`xds/internal/xdsclient/xdsresource/unmarshal_rds.go` | `xds/internal/clients/xdsclient/internal/testutils/unmarshal_rds.go` |